### PR TITLE
Handle HasRepped constraints.

### DIFF
--- a/plugin/Kitty/Plugin/Core/ErrorHandling.hs
+++ b/plugin/Kitty/Plugin/Core/ErrorHandling.hs
@@ -259,16 +259,6 @@ showFailure dflags hierarchyOptions = \case
     Kitty.Plugin.|]
         )
         unf
-  ConstraintNotFound expr constraint ->
-    [fmt|Kitty.Plugin encountered a `Data.Constraint.Dict`, but was unable to
-    find a `CoreExpr` of type `{showP constraint}` in the following expression:
-
-    {showE expr}
-
-    The desired type is usually contained in the first value arg of `baddDicts`
-    (i.e., `AllB c b`). Currently we only support 2-tuples for `AllB`, so
-    make sure all `AllB` definitions use nested 2-tuples only.
-    |]
   UnsupportedCast expr co ->
     [fmt|Kitty.Plugin can't apply the coercion `{showP $ Unpretty co}` to the expression
     {showP expr} :: {showP $ Plugins.exprType expr}|]


### PR DESCRIPTION
The Rep for a constraint is a dict, but there is no actual constraint held in
the tuple in this case, so we can't just look it up there. Instead, we now use
the usual `buildDictionary` approach if we fail to find the constraint in the
tuple.

This allows us to properly categorize GADTs with constraints in the
alternatives.