### PR TITLE
Remove Ormolu from default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -5,6 +5,5 @@ mkShell {
     (haskellPackages.ghcWithPackages (p: with p; [
       cabal-install
     ]))
-    ormolu # for Haskell formatting
   ];
 }


### PR DESCRIPTION
The version from nixpkgs is older than the version used by CI.