### PR TITLE
Separate Rep family from HasRep class.

### DIFF
--- a/category/Categorifier/Category.hs
+++ b/category/Categorifier/Category.hs
@@ -15,7 +15,7 @@ module Categorifier.Category
   )
 where
 
-import Categorifier.Client (HasRep (..))
+import Categorifier.Client (HasRep (..), Rep)
 import GHC.TypeLits (Symbol)
 import Unsafe.Coerce (unsafeCoerce)
 

--- a/client/Categorifier/Client.hs
+++ b/client/Categorifier/Client.hs
@@ -11,6 +11,7 @@
 --   @import qualified "Categorifier.Categorify" as Categorify@.
 module Categorifier.Client
   ( HasRep (..),
+    Rep,
     deriveHasRep,
 
     -- * testing
@@ -19,7 +20,7 @@ module Categorifier.Client
   )
 where
 
-import Categorifier.Client.Internal (HasRep (..), deriveHasRep)
+import Categorifier.Client.Internal (HasRep (..), Rep, deriveHasRep)
 import Data.Complex (Complex)
 import Data.Functor.Compose (Compose)
 import Data.Functor.Identity (Identity)

--- a/client/Categorifier/Client/Internal.hs
+++ b/client/Categorifier/Client/Internal.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies #-}
 
--- | This is separate from "Categorifier.Client" because we can't define Template Haskell and use it in
---   the same module. This module provides `deriveHasRep`, but it's private because importing it
---   would mean you miss the instances.
+-- | This is separate from "Categorifier.Client" because we can't define Template Haskell and use it
+--   in the same module. This module provides `deriveHasRep`, but the module is private because
+--   importing it directly would mean you miss the instances.
 module Categorifier.Client.Internal
   ( HasRep (..),
     Rep,
@@ -28,20 +28,22 @@ import Data.Tuple.Extra (fst3, snd3, thd3)
 import Data.Void (Void)
 import PyF (fmt)
 
--- | The "standard representation" that forms an isomorphism with the underlying type. This type
---   should only modify the current type (not the types contained within this one), and should
---   consist only of `Either`, `Void`, `()`, `(,)` (strictly 2-tuples), and `Dict`.
+-- | The "standard representation" that forms an isomorphism with the underlying type, @a@.
+--   @`Rep` a@ should roughly replace all the constructors of the underlying type with a combination
+--   of `Either`, `Void`, `()`, `(,)` (strictly 2-tuples), and `Dict`; leaving the types of the
+--   fields untouched.
 --
 --   E.g., the type
 -- > data Foo a = Num a => Bar a Int String | Baz (a -> a)
 --   would have an instance like the following
 -- > type instance Rep (Foo a) = Either (Dict (Num a), ((a, Int), String)) (a -> a)
---  (the specific tuple groupings and orderings are not important, so long as the isomorphism holds,
---   but making the structure as shallow as possible helps with performance).
+--   The specific tuple groupings and orderings are not important, so long as the isomorphism holds.
+--   However, making more balanced shallow structures, like @((a, b), (c, d))@, rather than biased
+--   deep structures, like @(a, (b, (c, d)))@, helps with performance.
 --
---   Existentials are not supported (as they're not supported by type families in general), but some
---   GADTs can be handled by creating multiple `HasRep` instances, one for each "return type" so
---   long as all the return types are disjoint (again, as type families don't allow overlapping).
+--   Existentials are not supported (as they're not supported by type families in general), but many
+--   GADTs can be handled by creating multiple `Rep` instances, at least one for each "return type".
+--   If the return types overlap, there may need to be additional `Rep` instances defined.
 --
 --  __NB__: The actual type here is considered an implementation detail, and should not be relied on
 --         (beyond the expectations provided above). Minor changes will not be considered breaking.

--- a/integrations/fin/integration/Categorifier/Fin/Client.hs
+++ b/integrations/fin/integration/Categorifier/Fin/Client.hs
@@ -5,11 +5,12 @@
 
 module Categorifier.Fin.Client
   ( HasRep (..),
+    Rep,
     deriveHasRep,
   )
 where
 
-import Categorifier.Client (HasRep (..), deriveHasRep)
+import Categorifier.Client (HasRep (..), Rep, deriveHasRep)
 import Data.Fin (Fin)
 import Data.Type.Nat (Nat (..), SNat (..))
 

--- a/integrations/vec/integration/Categorifier/Vec/Client.hs
+++ b/integrations/vec/integration/Categorifier/Vec/Client.hs
@@ -5,11 +5,12 @@
 
 module Categorifier.Vec.Client
   ( HasRep (..),
+    Rep,
     deriveHasRep,
   )
 where
 
-import Categorifier.Client (HasRep (..), deriveHasRep)
+import Categorifier.Client (HasRep (..), Rep, deriveHasRep)
 import Data.Vec.Lazy (Vec (..))
 
 deriveHasRep ''Vec


### PR DESCRIPTION
This reduces the work when dealing with GADTs with overlapping cases. Rather
than having to duplicate the entire class, we only need to duplicate the type
family.