### PR TITLE
Use flagRecompile instead of purePlugin

### DIFF
--- a/plugin/Categorifier.hs
+++ b/plugin/Categorifier.hs
@@ -37,7 +37,7 @@ plugin =
             . GhcPlugins.liftIO
             . liftA2 Categorifier.Core.install (partitionOptions' opts)
             . pure,
-      GhcPlugins.pluginRecompile = GhcPlugins.purePlugin
+      GhcPlugins.pluginRecompile = GhcPlugins.flagRecompile
     }
 
 partitionOptions' :: [GhcPlugins.CommandLineOption] -> IO (Map OptionGroup [Text])


### PR DESCRIPTION
The doc isn't super clear about this, but my understanding is that if we change the plugin, but does not change module `Foo` which uses the plugin, then with `purePlugin`, `Foo` may not be recompiled, and as such `purePlugin` is not the right thing to do.