### PR TITLE
GHC 9.0.1 default for develop shell (and direnv)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -173,8 +173,9 @@
               withHoogle = false;
             };
         in {
-          "default" = mkDevShell "ghc921";
+          "default" = mkDevShell "ghc901";
           "ghc8107" = mkDevShell "ghc8107";
+          "ghc901" = mkDevShell "ghc901";
           "ghc921" = mkDevShell "ghc921";
         };
       });


### PR DESCRIPTION
GHC 9.0.1 is currently a sweet spot for common development env, so made it as a default shell.
(nixos 22.05 default, categorifier-c is supported up to GHC 9.0.1 as of now and linear types and new stuff) 