### PR TITLE
Fix GHC 9.2.1 dev shell 

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,8 @@
                   # test is broken.
                   "barbies" = haskellLib.dontCheck super.barbies;
                   # linear-base 0.2.0
-                  "linear-base" =  self.callCabal2nix "linear-base" linear-base { };
+                  "linear-base" =
+                    self.callCabal2nix "linear-base" linear-base { };
                   # yaya 0.4.2.1
                   "yaya" = self.callCabal2nix "yaya" (yaya + "/core") { };
                 } // (prev.lib.optionalAttrs
@@ -60,10 +61,12 @@
                     "fin" = haskellLib.doJailbreak super.fin;
                     # ghc-lib-parser-ex-9.2.0.3
                     "ghc-lib-parser-ex" =
-                      self.callCabal2nix "ghc-lib-parser-ex" ghc-lib-parser-ex { };
+                      self.callCabal2nix "ghc-lib-parser-ex" ghc-lib-parser-ex
+                      { };
                     # loosen ghc-bignum bound on GHC-9.2.1
                     "ghc-typelits-natnormalise" =
-                      self.callCabal2nix "ghc-typelits-natnormalise" ghc-typelits-natnormalise { };
+                      self.callCabal2nix "ghc-typelits-natnormalise"
+                      ghc-typelits-natnormalise { };
                     # hlint-3.4
                     "hlint" = self.callCabal2nix "hlint" hlint { };
                     # loosen base bound on GHC-9.2.1

--- a/flake.nix
+++ b/flake.nix
@@ -157,6 +157,7 @@
                 overlays = [ overlayGHC concat.overlay.${system} ]
                   ++ fullOverlays;
                 inherit system;
+                config.allowBroken = true;
               };
 
             in newPkgs.haskellPackages.shellFor {


### PR DESCRIPTION
`nixpkgs.config.allowBroken = true` should be set as `linear-generics` build is broken in the upstream.
I think this is unnoticed because a local machine had that setting globally.
```
$ cd categorifier
direnv: loading ~/repo/src/categorifier/.envrc
direnv: using flake
error: Package ‘linear-generics-0.2’ in /nix/store/3g25cg20m43hvsy17d7nz0jxwk79a77w-source/pkgs/development/haskell-modules/hackage-packages.nix:168150 is marked as broken, refusing to evaluate.
```