### PR TITLE
Enable linear type support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         id: setup-haskell-cabal
         with:
           ghc-version: ${{ matrix.ghc }}
-          cabal-version: "3.6.0.0"
+          cabal-version: "3.8.1.0"
       - run: cabal v2-update
       - run: cabal v2-freeze $CONFIG
       - uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,12 @@ jobs:
         ghc:
           - "ghc884"
           - "ghc8107"
-          - "ghc901"
-          - "ghc921"
+          - "ghc902"
+          - "ghc922"
         os: [ubuntu-latest]
         experimental: [false]
         include:
-          - ghc: "ghc921"
+          - ghc: "ghc922"
             os: macos-latest
             experimental: false
           - ghc: "ghcHEAD"
@@ -46,7 +46,7 @@ jobs:
       matrix:
         ghc:
           - "8.10.1" # need an earlier revision than in Nix, because there's an API breakage that only affects 8.10.7
-          - "9.2.2" # there's an API breakage introduced here
+          - "9.2.1" # need an earlier revision than in Nix, because there's an API breakage introduced in 9.2.2
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:

--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@ You probably want to look at the [plugin README](./plugin/README.md).
 
 There are compatible [direnv](https://direnv.net/) and [Nix](https://nixos.org/manual/nix/stable/) environments in the repo to make it easy to build, test, etc. everything with consistent versions to help replicate issues.
 
+**NB**: If you build without Nix, be aware that the cabal.project file requires Cabal 3.8, but the individual *.cabal files are fine with Cabal 2.4.
+
 This repo is all formatted using [Ormolu](https://github.com/tweag/ormolu). Currently CI runs Ormolu 0.4.0.0, which can be installed by `cabal install ormolu-0.4.0.0`. See the [usage notes](https://github.com/tweag/ormolu#usage) for how to best integrate it with your workflow. But don't let Ormolu get in the way of contributing - CI will catch the formatting, and we can help clean up anything.

--- a/cabal.project
+++ b/cabal.project
@@ -31,9 +31,8 @@ source-repository-package
   tag: 99ee4981c096180abe99c24b12ff79e85d1817df
   subdir: satisfy
 
--- TODO: Uncomment with Cabal 3.8
--- program-options
---   ghc-options: -Werror
+program-options
+  ghc-options: -Werror
 
 tests: True
 
@@ -63,8 +62,7 @@ packages:
   ./plugin/categorifier-plugin.cabal
   ./plugin-test/categorifier-plugin-test.cabal
   ./th/categorifier-th.cabal
--- __TODO__: Uncomment below once Cabal 3.8 is released.
--- if impl(ghc >= 9.0.0)
---   packages:
---     ./integrations/linear-base/integration/categorifier-linear-base-integration.cabal
---     ./integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
+if impl(ghc >= 9.0.0)
+  packages:
+    ./integrations/linear-base/integration/categorifier-linear-base-integration.cabal
+    ./integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal

--- a/category/categorifier-category.cabal
+++ b/category/categorifier-category.cabal
@@ -6,7 +6,7 @@ description:    Classes used by categorifier plugin
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/client/categorifier-client.cabal
+++ b/client/categorifier-client.cabal
@@ -6,7 +6,7 @@ description:    Client library for the categorifier plugin
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -22,7 +22,7 @@ library
       Paths_categorifier_client
   ghc-options: -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.10
+    , PyF >=0.9.0 && <0.11
     , base >=4.13.0 && <4.17
     , categorifier-common
     , categorifier-duoids

--- a/common/categorifier-common.cabal
+++ b/common/categorifier-common.cabal
@@ -6,7 +6,7 @@ description:    Common library for the categorifier plugin
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -21,7 +21,7 @@ library
       Paths_categorifier_common
   ghc-options: -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.10
+    , PyF >=0.9.0 && <0.11
     , base >=4.13.0 && <4.17
     , unliftio >=0.2.13 && <0.3
   default-language: Haskell2010

--- a/duoids/categorifier-duoids.cabal
+++ b/duoids/categorifier-duoids.cabal
@@ -6,7 +6,7 @@ description:    Duoids
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/flake.lock
+++ b/flake.lock
@@ -42,32 +42,32 @@
     "linear-base": {
       "flake": false,
       "locked": {
-        "lastModified": 1648538481,
-        "narHash": "sha256-QceHuD9zA8fOoZ0AjIfUNGv5mQvj0sq0PAG3eXk1WuY=",
+        "lastModified": 1666796947,
+        "narHash": "sha256-wsjVVnVPzqIaNHNLsP/oAW2W7NKjfr4gl70zuPe3RM8=",
         "owner": "tweag",
         "repo": "linear-base",
-        "rev": "a3cb079b2425207620dc3bf899f74d052a66dde0",
+        "rev": "a899377327f9ade3247cab54c22b7ff7afca9f52",
         "type": "github"
       },
       "original": {
         "owner": "tweag",
-        "ref": "v0.2.0",
+        "ref": "v0.3.0",
         "repo": "linear-base",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1669546925,
-        "narHash": "sha256-Gvtk9agz88tBgqmCdHl5U7gYttTkiuEd8/Rq1Im0pTg=",
+        "lastModified": 1669764884,
+        "narHash": "sha256-1qWR/5+WtqxSedrFbUbM3zPMO7Ec2CGWaxtK4z4DdvY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fecf05d4861f3985e8dee73f08bc82668ef75125",
+        "rev": "0244e143dc943bcf661fdaf581f01eb0f5000fcf",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "release-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -2,7 +2,9 @@
   "nodes": {
     "concat": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-utils": [
+          "flake-utils"
+        ],
         "nixpkgs": [
           "nixpkgs"
         ]
@@ -24,77 +26,16 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1649676176,
-        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
-        "lastModified": 1652776076,
-        "narHash": "sha256-gzTw/v1vj4dOVbpBSJX4J0DwUR6LIyXo7/SuuTJp1kM=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "04c1b180862888302ddfb2e3ad9eaa63afc60cf8",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghc-lib-parser-ex": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-9ptNsJ7c8C147M7Ov4cPyeUHuLc8kmgKapLoIjCNjxQ=",
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-lib-parser-ex-9.2.0.3/ghc-lib-parser-ex-9.2.0.3.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://hackage.haskell.org/package/ghc-lib-parser-ex-9.2.0.3/ghc-lib-parser-ex-9.2.0.3.tar.gz"
-      }
-    },
-    "ghc-typelits-natnormalise": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1649255014,
-        "narHash": "sha256-NYbDIhQo+9xw0+16v0M+BRAVSYcThPhj+nTswSYxesM=",
-        "owner": "clash-lang",
-        "repo": "ghc-typelits-natnormalise",
-        "rev": "a68b722a6b10a932621dbf578f1408745a37a5ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "clash-lang",
-        "repo": "ghc-typelits-natnormalise",
-        "rev": "a68b722a6b10a932621dbf578f1408745a37a5ca",
-        "type": "github"
-      }
-    },
-    "hlint": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1650806052,
-        "narHash": "sha256-e3cXbpVAp5x9s03DRQf31++/nBSqcVufh21kJOy3c+A=",
-        "owner": "ndmitchell",
-        "repo": "hlint",
-        "rev": "cd529ad925bd40579bd0bef06f86cfae6c0da783",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ndmitchell",
-        "ref": "v3.4",
-        "repo": "hlint",
         "type": "github"
       }
     },
@@ -117,16 +58,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1653087707,
-        "narHash": "sha256-zfno3snrzZTWQ2B7K53QHrGZwrjnJLTRPalymrSsziU=",
+        "lastModified": 1669546925,
+        "narHash": "sha256-Gvtk9agz88tBgqmCdHl5U7gYttTkiuEd8/Rq1Im0pTg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "cbd40c72b2603ab54e7208f99f9b35fc158bc009",
+        "rev": "fecf05d4861f3985e8dee73f08bc82668ef75125",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-21.11",
+        "ref": "nixos-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -134,30 +75,9 @@
     "root": {
       "inputs": {
         "concat": "concat",
-        "flake-utils": "flake-utils_2",
-        "ghc-lib-parser-ex": "ghc-lib-parser-ex",
-        "ghc-typelits-natnormalise": "ghc-typelits-natnormalise",
-        "hlint": "hlint",
+        "flake-utils": "flake-utils",
         "linear-base": "linear-base",
-        "nixpkgs": "nixpkgs",
-        "yaya": "yaya"
-      }
-    },
-    "yaya": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1648062986,
-        "narHash": "sha256-9vI57ESpQG/c0zNSZSbwX/MFzUq+NvwfAAlMCcLaBa4=",
-        "owner": "sellout",
-        "repo": "yaya",
-        "rev": "c96718e6de9787284ace3602451f194ac7711ace",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sellout",
-        "repo": "yaya",
-        "rev": "c96718e6de9787284ace3602451f194ac7711ace",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,41 +1,19 @@
 {
   description = "categorifier";
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
     flake-utils.url = "github:numtide/flake-utils";
     concat = {
       url = "github:con-kitty/concat/wavewave-flake";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utlis.follows = "flake-utils";
-    };
-    yaya = {
-      # 0.4.2.1
-      url = "github:sellout/yaya/c96718e6de9787284ace3602451f194ac7711ace";
-      flake = false;
-    };
-    ghc-typelits-natnormalise = {
-      # 0.7.7
-      url =
-        "github:clash-lang/ghc-typelits-natnormalise/a68b722a6b10a932621dbf578f1408745a37a5ca";
-      flake = false;
-    };
-    hlint = {
-      url = "github:ndmitchell/hlint/v3.4";
-      flake = false;
+      inputs.flake-utils.follows = "flake-utils";
     };
     linear-base = {
       url = "github:tweag/linear-base/v0.2.0";
       flake = false;
     };
-    # this library git repo has an inconsistency in version bound increasing.
-    ghc-lib-parser-ex = {
-      url =
-        "https://hackage.haskell.org/package/ghc-lib-parser-ex-9.2.0.3/ghc-lib-parser-ex-9.2.0.3.tar.gz";
-      flake = false;
-    };
   };
-  outputs = { self, nixpkgs, flake-utils, concat, linear-base, yaya
-    , ghc-typelits-natnormalise, hlint, ghc-lib-parser-ex }:
+  outputs = { self, nixpkgs, flake-utils, concat, linear-base }:
     flake-utils.lib.eachSystem flake-utils.lib.allSystems (system:
       let
         haskellLib = (import nixpkgs { inherit system; }).haskell.lib;
@@ -54,31 +32,7 @@
                   # linear-base 0.2.0
                   "linear-base" =
                     self.callCabal2nix "linear-base" linear-base { };
-                  # yaya 0.4.2.1
-                  "yaya" = self.callCabal2nix "yaya" (yaya + "/core") { };
-                } // (prev.lib.optionalAttrs
-                  (prev.haskellPackages.ghc.version == "9.2.1") {
-                    # loose base bound
-                    "boring" = haskellLib.doJailbreak super.boring;
-                    # fin-0.2.1
-                    "fin" = haskellLib.doJailbreak super.fin;
-                    # ghc-lib-parser-ex-9.2.0.3
-                    "ghc-lib-parser-ex" =
-                      self.callCabal2nix "ghc-lib-parser-ex" ghc-lib-parser-ex
-                      { };
-                    # loosen ghc-bignum bound on GHC-9.2.1
-                    "ghc-typelits-natnormalise" =
-                      self.callCabal2nix "ghc-typelits-natnormalise"
-                      ghc-typelits-natnormalise { };
-                    # hlint-3.4
-                    "hlint" = self.callCabal2nix "hlint" hlint { };
-                    # loosen base bound on GHC-9.2.1
-                    "some" = haskellLib.doJailbreak super.some;
-                    # loosen base bound on GHC-9.2.1
-                    "universe-base" = super.universe-base_1_1_3;
-                    # loosen base bound on GHC-9.2.1
-                    "vec" = haskellLib.doJailbreak super.vec;
-                  }));
+                });
           });
         };
 
@@ -145,9 +99,12 @@
               };
             in individualPackages // { "${ghcVer}_all" = allEnv; };
 
-        in packagesOnGHC "ghc8107" // packagesOnGHC "ghc884"
-        // packagesOnGHC "ghc901" // packagesOnGHC "ghc921"
-        // packagesOnGHC "ghcHEAD";
+        in { default = self.packages.${system}.ghc902_all; }
+           // packagesOnGHC "ghc884"
+           // packagesOnGHC "ghc8107"
+           // packagesOnGHC "ghc902"
+           // packagesOnGHC "ghc922"
+           // packagesOnGHC "ghcHEAD";
 
         overlays = fullOverlays;
 
@@ -184,10 +141,12 @@
               withHoogle = false;
             };
         in {
-          "default" = mkDevShell "ghc901";
-          "ghc8107" = mkDevShell "ghc8107";
-          "ghc901" = mkDevShell "ghc901";
-          "ghc921" = mkDevShell "ghc921";
+          default = self.devShells.${system}.ghc902;
+          ghc884 = mkDevShell "ghc884";
+          ghc8107 = mkDevShell "ghc8107";
+          ghc902 = mkDevShell "ghc902";
+          ghc922 = mkDevShell "ghc922";
+          ghcHEAD = mkDevShell "ghcHEAD";
         };
       });
 }

--- a/ghc/categorifier-ghc.cabal
+++ b/ghc/categorifier-ghc.cabal
@@ -6,7 +6,7 @@ description:    GHC-as-a-library conditionalization for Categorifier
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -33,7 +33,7 @@ library
     -fignore-interface-pragmas
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.10
+    , PyF >=0.9.0 && <0.11
     , base >=4.13.0 && <4.17
     , bytestring >=0.10.9 && <0.12
     , containers >=0.6.2 && <0.7

--- a/hedgehog/categorifier-hedgehog.cabal
+++ b/hedgehog/categorifier-hedgehog.cabal
@@ -6,7 +6,7 @@ description:    Additional functions to assist testing with Hedgehog.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
+++ b/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Test utilities for categorifier's adjunctions integration.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
+++ b/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to Conal's ConCat to improve plugin coverage.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
+++ b/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Plugin using Kmett's Categories classes.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/categories/integration/categorifier-categories-integration.cabal
+++ b/integrations/categories/integration/categorifier-categories-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to use Kmett's Categories with the plugin.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
+++ b/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
@@ -6,7 +6,7 @@ description:    Categorical classes extending Conal's ConCat
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
+++ b/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Plugin using our extensions to Conal's ConCat functions.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
+++ b/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to Conal's ConCat to improve plugin coverage.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/concat/examples/categorifier-concat-examples.cabal
+++ b/integrations/concat/examples/categorifier-concat-examples.cabal
@@ -6,7 +6,7 @@ description:    Extra instances to use concat-examples with Categorifier.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
+++ b/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Utilities for testing ConCat and extensions of it.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/concat/integration/categorifier-concat-integration.cabal
+++ b/integrations/concat/integration/categorifier-concat-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to use Conal's ConCat with the plugin.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/fin/integration/categorifier-fin-integration.cabal
+++ b/integrations/fin/integration/categorifier-fin-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to Conal's ConCat to improve plugin coverage.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
+++ b/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Test utilities for categorifier's linear-base integration.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.4.1, GHC==8.6.1, GHC==8.8.1, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -26,8 +26,7 @@ library
   build-depends:
     , base >=4.13.0 && <4.17
     , categorifier-plugin-test
-    , linear-base >=0.2.0 && <0.3
-    , pointed >=5.0.0 && <5.1
+    , linear-base >=0.3.0 && <0.4
     , vector >=0.12.2 && <0.13
   default-language: Haskell2010
   default-extensions:
@@ -80,7 +79,8 @@ test-suite linear-base-hierarchy
     , either >=5.0.1 && <5.1
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.2
-    , linear-base >=0.2.0 && <0.3
+    , linear-base >=0.3.0 && <0.4
+    , pointed >=5.0.0 && <5.1
     , template-haskell >=2.15.0 && <2.19
 
 test-suite linear-base-hierarchy-optimized
@@ -116,5 +116,6 @@ test-suite linear-base-hierarchy-optimized
     , either >=5.0.1 && <5.1
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.2
-    , linear-base >=0.2.0 && <0.3
+    , linear-base >=0.3.0 && <0.4
+    , pointed >=5.0.0 && <5.1
     , template-haskell >=2.15.0 && <2.19

--- a/integrations/linear-base/integration-test/test/LinearBase/Main.hs
+++ b/integrations/linear-base/integration-test/test/LinearBase/Main.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE TypeApplications #-}
 -- To avoid turning @if then else@ into `ifThenElse`.
 {-# LANGUAGE NoRebindableSyntax #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 -- | See @Test/Cat/ConCat/Main.hs@ for copious notes on the testing situation here.
 module Main
@@ -38,6 +39,7 @@ import Data.Proxy (Proxy (..))
 import qualified Data.Replicator.Linear
 import qualified Data.V.Linear
 import GHC.Int (Int64)
+import GHC.TypeLits (KnownNat)
 import GHC.Word (Word8)
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range

--- a/integrations/linear-base/integration/Categorifier/LinearBase/Client.hs
+++ b/integrations/linear-base/integration/Categorifier/LinearBase/Client.hs
@@ -16,7 +16,6 @@ import Data.Array.Destination (DArray)
 import qualified Data.Array.Polarized.Pull as Pull
 import Data.HashMap.Mutable.Linear (HashMap)
 import Data.Monoid.Linear (Endo, NonLinear)
-import Data.Num.Linear (Adding, Multiplying)
 import Data.Profunctor.Kleisli.Linear (CoKleisli, Kleisli)
 import Data.Profunctor.Linear (Exchange, Market)
 import Data.Replicator.Linear (Replicator)
@@ -28,9 +27,9 @@ import Foreign.Marshal.Pure (Box, Pool)
 import Prelude.Linear.Generically (Generically, Generically1)
 import Streaming.Linear (Of, Stream)
 import Streaming.Prelude.Linear (Either3)
-import System.IO.Resource.Linear (Handle, RIO, UnsafeResource)
+import System.IO.Resource.Linear (RIO)
+import System.IO.Resource.Linear.Internal (Resource)
 
-deriveHasRep ''Adding
 deriveHasRep ''AsMovable
 deriveHasRep ''Box
 deriveHasRep ''CoKleisli
@@ -41,12 +40,10 @@ deriveHasRep ''Endo
 deriveHasRep ''Exchange
 deriveHasRep ''Generically
 deriveHasRep ''Generically1
-deriveHasRep ''Handle
 deriveHasRep ''HashMap
 deriveHasRep ''Kleisli
 deriveHasRep ''Market
 deriveHasRep ''MovableMonoid
-deriveHasRep ''Multiplying
 deriveHasRep ''NonLinear
 deriveHasRep ''Of
 deriveHasRep ''Optic_
@@ -56,10 +53,10 @@ deriveHasRep ''Pull.Array
 deriveHasRep ''RIO
 deriveHasRep ''ReaderT
 deriveHasRep ''Replicator
+deriveHasRep ''Resource
 deriveHasRep ''Set
 deriveHasRep ''StateT
 deriveHasRep ''Stream
-deriveHasRep ''UnsafeResource
 deriveHasRep ''Ur
 deriveHasRep ''UrT
 deriveHasRep ''V

--- a/integrations/linear-base/integration/Categorifier/LinearBase/Integration.hs
+++ b/integrations/linear-base/integration/Categorifier/LinearBase/Integration.hs
@@ -53,74 +53,13 @@ import qualified Prelude.Linear
 import qualified Streaming.Prelude.Linear
 import qualified Unsafe.Linear
 
--- These instances are pushed upstream in https://github.com/tweag/linear-base/pull/416 and should
--- be in any release of linear-base >0.2.0
-
--- | @linear-base@ doesn't export `MovableOrd`, so we redefine it and its instances here to use in
---   @newtype@-derived instances.
-newtype MovableOrd a = MovableOrd a
-
-instance (Eq a, Prelude.Linear.Movable a) => Data.Ord.Linear.Eq (MovableOrd a) where
-  MovableOrd ar == MovableOrd br =
-    Prelude.Linear.move (ar, br) Prelude.Linear.& \(Prelude.Linear.Ur (a, b)) -> a == b
-  MovableOrd ar /= MovableOrd br =
-    Prelude.Linear.move (ar, br) Prelude.Linear.& \(Prelude.Linear.Ur (a, b)) -> a /= b
-
-instance (Prelude.Ord a, Prelude.Linear.Movable a) => Data.Ord.Linear.Ord (MovableOrd a) where
-  MovableOrd ar `compare` MovableOrd br =
-    Prelude.Linear.move (ar, br)
-      Prelude.Linear.& \(Prelude.Linear.Ur (a, b)) -> a `Prelude.compare` b
-
-deriving via MovableOrd Int16 instance Data.Ord.Linear.Eq Int16
-
-deriving via MovableOrd Int32 instance Data.Ord.Linear.Eq Int32
-
-deriving via MovableOrd Int64 instance Data.Ord.Linear.Eq Int64
-
-deriving via MovableOrd Int8 instance Data.Ord.Linear.Eq Int8
-
-deriving via MovableOrd Word16 instance Data.Ord.Linear.Eq Word16
-
-deriving via MovableOrd Word32 instance Data.Ord.Linear.Eq Word32
-
-deriving via MovableOrd Word64 instance Data.Ord.Linear.Eq Word64
-
-deriving via MovableOrd Word8 instance Data.Ord.Linear.Eq Word8
-
-deriving via MovableOrd Int16 instance Data.Ord.Linear.Ord Int16
-
-deriving via MovableOrd Int32 instance Data.Ord.Linear.Ord Int32
-
-deriving via MovableOrd Int64 instance Data.Ord.Linear.Ord Int64
-
-deriving via MovableOrd Int8 instance Data.Ord.Linear.Ord Int8
-
-deriving via MovableOrd Word16 instance Data.Ord.Linear.Ord Word16
-
-deriving via MovableOrd Word32 instance Data.Ord.Linear.Ord Word32
-
-deriving via MovableOrd Word64 instance Data.Ord.Linear.Ord Word64
-
-deriving via MovableOrd Word8 instance Data.Ord.Linear.Ord Word8
-
-deriving instance Show (Data.V.Linear.V n a)
-
-deriving instance Foldable (Data.V.Linear.V n)
-
-deriving instance KnownNat n => Traversable (Data.V.Linear.V n)
-
-instance KnownNat n => Applicative (Data.V.Linear.V n) where
-  pure = Data.Functor.Linear.pure
-  Data.V.Linear.Internal.V fs <*> Data.V.Linear.Internal.V xs =
-    Data.V.Linear.Internal.V $ Vector.zipWith (\f x -> f $ x) fs xs
-
 symbolLookup :: Lookup SymbolLookup
 symbolLookup = do
-  array <- findTyCon "Data.Array.Mutable.Linear" "Array"
-  arrayUnlifted <- findTyCon "Data.Array.Mutable.Unlifted.Linear" "Array#"
-  replicator <- findTyCon "Data.Replicator.Linear" "Replicator"
-  v <- findTyCon "Data.V.Linear" "V"
-  stream <- findTyCon "Streaming.Prelude.Linear" "Stream"
+  array <- findTyCon ''Data.Array.Mutable.Linear.Array
+  arrayUnlifted <- findTyCon ''Data.Array.Mutable.Unlifted.Linear.Array#
+  replicator <- findTyCon ''Data.Replicator.Linear.Replicator
+  v <- findTyCon ''Data.V.Linear.V
+  stream <- findTyCon ''Streaming.Prelude.Linear.Stream
   pure $
     SymbolLookup
       ( Map.fromList

--- a/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
+++ b/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to Conal's ConCat to improve plugin coverage.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.4.1, GHC==8.6.1, GHC==8.8.1, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -28,7 +28,7 @@ library
     , categorifier-ghc
     , categorifier-plugin
     , containers >=0.6.2 && <0.7
-    , linear-base >=0.2.0 && <0.3
+    , linear-base >=0.3.0 && <0.4
     , template-haskell >=2.15.0 && <2.19
     , transformers >=0.5.6 && <0.7
   default-language: Haskell2010

--- a/integrations/unconcat/category/categorifier-unconcat-category.cabal
+++ b/integrations/unconcat/category/categorifier-unconcat-category.cabal
@@ -9,7 +9,7 @@ description:    Unconstrained versions of Conal's ConCat classes. They can be us
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
+++ b/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Plugin using our extensions to Conal's ConCat functions.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
+++ b/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to Conal's ConCat to improve plugin coverage.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
+++ b/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
@@ -6,7 +6,7 @@ description:    Test utilities for categorifier's vec integration.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/integrations/vec/integration/categorifier-vec-integration.cabal
+++ b/integrations/vec/integration/categorifier-vec-integration.cabal
@@ -6,7 +6,7 @@ description:    Extensions to Conal's ConCat to improve plugin coverage.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git

--- a/plugin-test/categorifier-plugin-test.cabal
+++ b/plugin-test/categorifier-plugin-test.cabal
@@ -6,7 +6,7 @@ description:    Framework for testing integration to the plugin.
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -36,7 +36,7 @@ library
     -O2
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.10
+    , PyF >=0.9.0 && <0.11
     , adjunctions >=4.4 && <4.5
     , base >=4.13.0 && <4.17
     , categorifier-category

--- a/plugin-test/categorifier-plugin-test.cabal
+++ b/plugin-test/categorifier-plugin-test.cabal
@@ -53,7 +53,7 @@ library
     , text >=1.2.4 && <1.3
     , vec >=0.3 && <0.5
   if impl(ghc >= 9.0.0)
-    build-depends: linear-base >=0.2.0 && <0.3
+    build-depends: linear-base >=0.3.0 && <0.4
   default-language: Haskell2010
   default-extensions:
       InstanceSigs

--- a/plugin/categorifier-plugin.cabal
+++ b/plugin/categorifier-plugin.cabal
@@ -6,7 +6,7 @@ description:    GHC plugin for Compiling to Categories
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -44,7 +44,7 @@ library
     -fignore-interface-pragmas
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.10
+    , PyF >=0.9.0 && <0.11
     , barbies >=2.0.1 && <2.1
     , base >=4.13.0 && <4.17
     , bytestring >=0.10.9 && <0.12

--- a/th/categorifier-th.cabal
+++ b/th/categorifier-th.cabal
@@ -6,7 +6,7 @@ description:    template-haskell extensions for Categorifier
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
 build-type:     Simple
-tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2
+tested-with:    GHC==8.8.4, GHC==8.10.1, GHC==8.10.7, GHC==9.0.2, GHC==9.2.1, GHC==9.2.2
 
 source-repository head
   type: git
@@ -23,7 +23,7 @@ library
     -fignore-interface-pragmas
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.10
+    , PyF >=0.9.0 && <0.11
     , base >=4.13.0 && <4.17
     , categorifier-common
     , categorifier-duoids


### PR DESCRIPTION
This has been in the repo for months, but had to be disabled in the build until
Cabal 3.8 was available.