### PR TITLE
Cabal file improvements

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,34 +2,15 @@ source-repository-package
   type: git
   location: https://github.com/compiling-to-categories/concat.git
   tag: d95c79d23f2728f2ab50497760195fffaf4ba675
-  subdir: classes
-
-source-repository-package
-  type: git
-  location: https://github.com/compiling-to-categories/concat.git
-  tag: d95c79d23f2728f2ab50497760195fffaf4ba675
-  subdir: examples
-
--- dependency of concat-classes, concat-examples
-source-repository-package
-  type: git
-  location: https://github.com/compiling-to-categories/concat.git
-  tag: d95c79d23f2728f2ab50497760195fffaf4ba675
-  subdir: inline
-
--- dependency of concat-classes, concat-examples
-source-repository-package
-  type: git
-  location: https://github.com/compiling-to-categories/concat.git
-  tag: d95c79d23f2728f2ab50497760195fffaf4ba675
-  subdir: known
-
--- dependency of concat-classes
-source-repository-package
-  type: git
-  location: https://github.com/compiling-to-categories/concat.git
-  tag: d95c79d23f2728f2ab50497760195fffaf4ba675
-  subdir: satisfy
+  subdir:
+    classes
+    examples
+    -- dependency of concat-classes, concat-examples
+    inline
+    -- dependency of concat-classes, concat-examples
+    known
+    -- dependency of concat-classes
+    satisfy
 
 program-options
   ghc-options: -Werror

--- a/category/categorifier-category.cabal
+++ b/category/categorifier-category.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/category/categorifier-category.cabal
+++ b/category/categorifier-category.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs

--- a/category/categorifier-category.cabal
+++ b/category/categorifier-category.cabal
@@ -12,19 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Category
-  other-modules:
-      Paths_categorifier_category
-  autogen-modules:
-      Paths_categorifier_category
+common defaults
   ghc-options:
-    -O2
     -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , categorifier-client
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -43,3 +35,17 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Category
+  other-modules:
+      Paths_categorifier_category
+  autogen-modules:
+      Paths_categorifier_category
+  ghc-options:
+    -O2
+    -Wall
+  build-depends:
+    , categorifier-client

--- a/client/categorifier-client.cabal
+++ b/client/categorifier-client.cabal
@@ -20,22 +20,22 @@ common defaults
     , constraints ^>=0.12.0 || ^>=0.13.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/client/categorifier-client.cabal
+++ b/client/categorifier-client.cabal
@@ -16,8 +16,8 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
-    , constraints >=0.12 && <0.14
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
+    , constraints ^>=0.12.0 || ^>=0.13.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -47,11 +47,11 @@ library
   autogen-modules:
       Paths_categorifier_client
   build-depends:
-    , PyF >=0.9.0 && <0.12
+    , PyF ^>=0.9.0 || ^>=0.10.0 || ^>=0.11.0
     , categorifier-common
     , categorifier-duoids
     , categorifier-th
-    , extra >=1.7.8 && <1.8
+    , extra ^>=1.7.8
 
 test-suite client-instances
   import: defaults
@@ -61,5 +61,5 @@ test-suite client-instances
   build-depends:
     , categorifier-client
     , categorifier-hedgehog
-    , fin >=0.1.1 && <0.4
-    , hedgehog >=1.0.3 && <1.3
+    , fin ^>=0.1.1 || ^>=0.2 || ^>=0.3
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2

--- a/client/categorifier-client.cabal
+++ b/client/categorifier-client.cabal
@@ -12,23 +12,12 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Client
-  other-modules:
-      Categorifier.Client.Internal
-      Paths_categorifier_client
-  autogen-modules:
-      Paths_categorifier_client
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.12
     , base >=4.13.0 && <4.17
-    , categorifier-common
-    , categorifier-duoids
-    , categorifier-th
     , constraints >=0.12 && <0.14
-    , extra >=1.7.8 && <1.8
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -48,31 +37,29 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Client
+  other-modules:
+      Categorifier.Client.Internal
+      Paths_categorifier_client
+  autogen-modules:
+      Paths_categorifier_client
+  build-depends:
+    , PyF >=0.9.0 && <0.12
+    , categorifier-common
+    , categorifier-duoids
+    , categorifier-th
+    , extra >=1.7.8 && <1.8
+
 test-suite client-instances
+  import: defaults
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: Main.hs
   build-depends:
-    , base >=4.13.0 && <4.17
     , categorifier-client
     , categorifier-hedgehog
-    , constraints >=0.12 && <0.14
     , fin >=0.1.1 && <0.4
     , hedgehog >=1.0.3 && <1.3
-  default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies

--- a/common/categorifier-common.cabal
+++ b/common/categorifier-common.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/common/categorifier-common.cabal
+++ b/common/categorifier-common.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,5 +45,5 @@ library
   autogen-modules:
       Paths_categorifier_common
   build-depends:
-    , PyF >=0.9.0 && <0.12
-    , unliftio >=0.2.13 && <0.3
+    , PyF ^>=0.9.0 || ^>=0.10.0 || ^>=0.11.0
+    , unliftio ^>=0.2.13

--- a/common/categorifier-common.cabal
+++ b/common/categorifier-common.cabal
@@ -12,18 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Common.IO.Exception
-  other-modules:
-      Paths_categorifier_common
-  autogen-modules:
-      Paths_categorifier_common
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.12
     , base >=4.13.0 && <4.17
-    , unliftio >=0.2.13 && <0.3
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -42,3 +35,15 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Common.IO.Exception
+  other-modules:
+      Paths_categorifier_common
+  autogen-modules:
+      Paths_categorifier_common
+  build-depends:
+    , PyF >=0.9.0 && <0.12
+    , unliftio >=0.2.13 && <0.3

--- a/duoids/categorifier-duoids.cabal
+++ b/duoids/categorifier-duoids.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/duoids/categorifier-duoids.cabal
+++ b/duoids/categorifier-duoids.cabal
@@ -12,18 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Duoidal
-      Categorifier.Duoidal.Either
-  other-modules:
-      Paths_categorifier_duoids
-  autogen-modules:
-      Paths_categorifier_duoids
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -42,3 +35,15 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Duoidal
+      Categorifier.Duoidal.Either
+  other-modules:
+      Paths_categorifier_duoids
+  autogen-modules:
+      Paths_categorifier_duoids
+  build-depends:
+    , transformers >=0.5.6 && <0.7

--- a/duoids/categorifier-duoids.cabal
+++ b/duoids/categorifier-duoids.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -46,4 +46,4 @@ library
   autogen-modules:
       Paths_categorifier_duoids
   build-depends:
-    , transformers >=0.5.6 && <0.7
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/ghc/categorifier-ghc.cabal
+++ b/ghc/categorifier-ghc.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/ghc/categorifier-ghc.cabal
+++ b/ghc/categorifier-ghc.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -57,7 +57,7 @@ library
     -O2
     -fignore-interface-pragmas
   build-depends:
-    , PyF >=0.9.0 && <0.12
-    , bytestring >=0.10.9 && <0.12
-    , containers >=0.6.2 && <0.7
-    , ghc >=8.8.1 && <9.4
+    , PyF ^>=0.9.0 || ^>=0.10.0 || ^>=0.11.0
+    , bytestring ^>=0.10.9 || ^>=0.11.0
+    , containers ^>=0.6.2
+    , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1

--- a/ghc/categorifier-ghc.cabal
+++ b/ghc/categorifier-ghc.cabal
@@ -12,32 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.GHC.Builtin
-      Categorifier.GHC.Core
-      Categorifier.GHC.Data
-      Categorifier.GHC.Driver
-      Categorifier.GHC.HsToCore
-      Categorifier.GHC.Plugins
-      Categorifier.GHC.Runtime
-      Categorifier.GHC.Tc
-      Categorifier.GHC.Types
-      Categorifier.GHC.Unit
-      Categorifier.GHC.Utils
-      Paths_categorifier_ghc
-  autogen-modules:
-      Paths_categorifier_ghc
+common defaults
   ghc-options:
-    -O2
-    -fignore-interface-pragmas
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.12
     , base >=4.13.0 && <4.17
-    , bytestring >=0.10.9 && <0.12
-    , containers >=0.6.2 && <0.7
-    , ghc >=8.8.1 && <9.4
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -56,3 +35,29 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.GHC.Builtin
+      Categorifier.GHC.Core
+      Categorifier.GHC.Data
+      Categorifier.GHC.Driver
+      Categorifier.GHC.HsToCore
+      Categorifier.GHC.Plugins
+      Categorifier.GHC.Runtime
+      Categorifier.GHC.Tc
+      Categorifier.GHC.Types
+      Categorifier.GHC.Unit
+      Categorifier.GHC.Utils
+      Paths_categorifier_ghc
+  autogen-modules:
+      Paths_categorifier_ghc
+  ghc-options:
+    -O2
+    -fignore-interface-pragmas
+  build-depends:
+    , PyF >=0.9.0 && <0.12
+    , bytestring >=0.10.9 && <0.12
+    , containers >=0.6.2 && <0.7
+    , ghc >=8.8.1 && <9.4

--- a/hedgehog/categorifier-hedgehog.cabal
+++ b/hedgehog/categorifier-hedgehog.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/hedgehog/categorifier-hedgehog.cabal
+++ b/hedgehog/categorifier-hedgehog.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,4 +45,4 @@ library
   autogen-modules:
       Paths_categorifier_hedgehog
   build-depends:
-    , hedgehog >=1.0.3 && <1.3
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2

--- a/hedgehog/categorifier-hedgehog.cabal
+++ b/hedgehog/categorifier-hedgehog.cabal
@@ -12,17 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Hedgehog
-  other-modules:
-      Paths_categorifier_hedgehog
-  autogen-modules:
-      Paths_categorifier_hedgehog
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , hedgehog >=1.0.3 && <1.3
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -41,3 +35,14 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Hedgehog
+  other-modules:
+      Paths_categorifier_hedgehog
+  autogen-modules:
+      Paths_categorifier_hedgehog
+  build-depends:
+    , hedgehog >=1.0.3 && <1.3

--- a/integrations/adjunctions/integration-test/Categorifier/Test/Adjunctions.hs
+++ b/integrations/adjunctions/integration-test/Categorifier/Test/Adjunctions.hs
@@ -12,7 +12,7 @@ module Categorifier.Test.Adjunctions
 where
 
 import Categorifier.Test.HList (HMap1 (..))
-import Categorifier.Test.TH (mkBinaryTestConfig, mkExprTest, mkUnaryTestConfig)
+import Categorifier.Test.TH (mkBinaryTestConfig, mkUnaryTestConfig)
 import Categorifier.Test.Tests (TestTerms, insertTest)
 import Data.Functor.Identity (Identity (..))
 import qualified Data.Functor.Rep as Representable

--- a/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
+++ b/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
@@ -21,22 +21,22 @@ common defaults
     , categorifier-plugin-test
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
+++ b/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
@@ -16,8 +16,8 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
+    , adjunctions ^>=4.4
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-plugin-test
   default-language: Haskell2010
   default-extensions:
@@ -60,7 +60,7 @@ common hierarchy-tests
     -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
     -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
   build-depends:
-    , categories >=1.0.7 && <1.1
+    , categories ^>=1.0.7
     , categorifier-adjunctions-integration
     , categorifier-adjunctions-integration-test
     , categorifier-categories-integration
@@ -69,9 +69,9 @@ common hierarchy-tests
     , categorifier-client
     , categorifier-hedgehog
     , categorifier-plugin
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite adjunctions-hierarchy
   import: hierarchy-tests

--- a/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
+++ b/integrations/adjunctions/integration-test/categorifier-adjunctions-integration-test.cabal
@@ -12,17 +12,9 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
     -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.Adjunctions
   build-depends:
     , adjunctions >=4.4 && <4.5
     , base >=4.13.0 && <4.17
@@ -46,12 +38,19 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite adjunctions-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.Adjunctions
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: Adjunctions/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -fplugin-opt Categorifier:defer-failures
     -fplugin-opt Categorifier:hierarchy:Categorifier.Adjunctions.Integration.hierarchy
@@ -60,10 +59,7 @@ test-suite adjunctions-hierarchy
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.Categories.hierarchy
     -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
     -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -O0
   build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
     , categories >=1.0.7 && <1.1
     , categorifier-adjunctions-integration
     , categorifier-adjunctions-integration-test
@@ -73,39 +69,21 @@ test-suite adjunctions-hierarchy
     , categorifier-client
     , categorifier-hedgehog
     , categorifier-plugin
-    , categorifier-plugin-test
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
 
-test-suite adjunctions-hierarchy-optimized
-  import: options
+test-suite adjunctions-hierarchy
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: Adjunctions/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Adjunctions.Integration.hierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.baseHierarchy
-    -- need `curry` for some tests, so we add the categories hierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.Categories.hierarchy
-    -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
+    -O0
+
+test-suite adjunctions-hierarchy-optimized
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: Adjunctions/Main.hs
+  ghc-options:
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categories >=1.0.7 && <1.1
-    , categorifier-adjunctions-integration
-    , categorifier-adjunctions-integration-test
-    , categorifier-categories-integration
-    , categorifier-categories-integration-test
-    , categorifier-category
-    , categorifier-client
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
+++ b/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
+++ b/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
@@ -12,23 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Adjunctions.Integration
-  other-modules:
-      Paths_categorifier_adjunctions_integration
-  autogen-modules:
-      Paths_categorifier_adjunctions_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , adjunctions >=4.4 && <4.5
     , base >=4.13.0 && <4.17
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -47,3 +35,20 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Adjunctions.Integration
+  other-modules:
+      Paths_categorifier_adjunctions_integration
+  autogen-modules:
+      Paths_categorifier_adjunctions_integration
+  build-depends:
+    , adjunctions >=4.4 && <4.5
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , containers >=0.6.2 && <0.7
+    , template-haskell >=2.15.0 && <2.19
+    , transformers >=0.5.6 && <0.7

--- a/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
+++ b/integrations/adjunctions/integration/categorifier-adjunctions-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,10 +45,10 @@ library
   autogen-modules:
       Paths_categorifier_adjunctions_integration
   build-depends:
-    , adjunctions >=4.4 && <4.5
+    , adjunctions ^>=4.4
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
+    , containers ^>=0.6.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
+++ b/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
@@ -21,22 +21,22 @@ common defaults
     , categorifier-plugin-test
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
+++ b/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
@@ -12,17 +12,9 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
     -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.Categories.Instances
   build-depends:
     , base >=4.13.0 && <4.17
     , categories >=1.0.7 && <1.1
@@ -46,19 +38,20 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite categories-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.Categories.Instances
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: Categories/Main.hs
   ghc-options:
     -fplugin Categorifier
     -- -fplugin-opt Categorifier:defer-failures
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.Categories.hierarchy
-    -O0
   build-depends:
     , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
     , categories >=1.0.7 && <1.1
     , categorifier-categories-integration
     , categorifier-categories-integration-test
@@ -72,29 +65,17 @@ test-suite categories-hierarchy
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
 
-test-suite categories-hierarchy-optimized
-  import: options
+test-suite categories-hierarchy
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: Categories/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -- -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.Categories.hierarchy
+    -O0
+
+test-suite categories-hierarchy-optimized
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: Categories/Main.hs
+  ghc-options:
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categories >=1.0.7 && <1.1
-    , categorifier-categories-integration
-    , categorifier-categories-integration-test
-    , categorifier-category
-    , categorifier-client
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
+++ b/integrations/categories/integration-test/categorifier-categories-integration-test.cabal
@@ -16,8 +16,8 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
-    , categories >=1.0.7 && <1.1
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
+    , categories ^>=1.0.7
     , categorifier-plugin-test
   default-language: Haskell2010
   default-extensions:
@@ -51,8 +51,8 @@ common hierarchy-tests
     -- -fplugin-opt Categorifier:defer-failures
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.Categories.hierarchy
   build-depends:
-    , adjunctions >=4.4 && <4.5
-    , categories >=1.0.7 && <1.1
+    , adjunctions ^>=4.4
+    , categories ^>=1.0.7
     , categorifier-categories-integration
     , categorifier-categories-integration-test
     , categorifier-category
@@ -60,10 +60,10 @@ common hierarchy-tests
     , categorifier-hedgehog
     , categorifier-plugin
     , categorifier-plugin-test
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , either ^>=5.0.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite categories-hierarchy
   import: hierarchy-tests

--- a/integrations/categories/integration/categorifier-categories-integration.cabal
+++ b/integrations/categories/integration/categorifier-categories-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/categories/integration/categorifier-categories-integration.cabal
+++ b/integrations/categories/integration/categorifier-categories-integration.cabal
@@ -12,23 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Hierarchy.Categories
-  other-modules:
-      Paths_categorifier_categories_integration
-  autogen-modules:
-      Paths_categorifier_categories_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , bytestring >=0.10.9 && <0.12
-    , categories >=1.0.7 && <1.1
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -47,3 +35,20 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Hierarchy.Categories
+  other-modules:
+      Paths_categorifier_categories_integration
+  autogen-modules:
+      Paths_categorifier_categories_integration
+  build-depends:
+    , bytestring >=0.10.9 && <0.12
+    , categories >=1.0.7 && <1.1
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , ghc-prim >=0.5.3 && <0.9
+    , transformers >=0.5.6 && <0.7

--- a/integrations/categories/integration/categorifier-categories-integration.cabal
+++ b/integrations/categories/integration/categorifier-categories-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,10 +45,10 @@ library
   autogen-modules:
       Paths_categorifier_categories_integration
   build-depends:
-    , bytestring >=0.10.9 && <0.12
-    , categories >=1.0.7 && <1.1
+    , bytestring ^>=0.10.9 || ^>=0.11.0
+    , categories ^>=1.0.7
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
+++ b/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
+++ b/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs

--- a/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
+++ b/integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
@@ -12,19 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.ConCatExtensions
-  other-modules:
-      Paths_categorifier_concat_extensions_category
-  autogen-modules:
-      Paths_categorifier_concat_extensions_category
+common defaults
   ghc-options:
-    -O2
     -Wall
   build-depends:
-    , base >=4.11.0 && <4.17
-    , concat-classes
+    , base >=4.13.0 && <4.17
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -43,3 +35,16 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.ConCatExtensions
+  other-modules:
+      Paths_categorifier_concat_extensions_category
+  autogen-modules:
+      Paths_categorifier_concat_extensions_category
+  ghc-options:
+    -O2
+  build-depends:
+    , concat-classes

--- a/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
+++ b/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
@@ -12,20 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
     -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.ConCatExtensions.Instances
   build-depends:
     , base >=4.11.0 && <4.17
-    , categorifier-concat-integration-test
     , categorifier-concat-extensions-category
     , categorifier-plugin-test
     , concat-classes
@@ -48,61 +39,51 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite concat-extensions-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.ConCatExtensions.Instances
+  build-depends:
+    , categorifier-concat-integration-test
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: ConCatExtensions/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
-    -O0
   build-depends:
     , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
     , categorifier-category
     , categorifier-client
     , categorifier-concat-integration
-    , categorifier-hedgehog
-    , categorifier-concat-extensions-category
     , categorifier-concat-extensions-integration
     , categorifier-concat-extensions-integration-test
+    , categorifier-hedgehog
     , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
     , concat-examples
     , either >=5.0.1 && <5.1
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
 
+test-suite concat-extensions-hierarchy
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: ConCatExtensions/Main.hs
+  ghc-options:
+    -O0
+
 test-suite concat-extensions-hierarchy-optimized
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
   hs-source-dirs: test
   main-is: ConCatExtensions/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-integration
-    , categorifier-hedgehog
-    , categorifier-concat-extensions-category
-    , categorifier-concat-extensions-integration
-    , categorifier-concat-extensions-integration-test
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
+++ b/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
@@ -22,22 +22,22 @@ common defaults
     , concat-classes
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
+++ b/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.11.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-concat-extensions-category
     , categorifier-plugin-test
     , concat-classes
@@ -58,7 +58,7 @@ common hierarchy-tests
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
   build-depends:
-    , adjunctions >=4.4 && <4.5
+    , adjunctions ^>=4.4
     , categorifier-category
     , categorifier-client
     , categorifier-concat-integration
@@ -67,10 +67,10 @@ common hierarchy-tests
     , categorifier-hedgehog
     , categorifier-plugin
     , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , either ^>=5.0.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite concat-extensions-hierarchy
   import: hierarchy-tests

--- a/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
+++ b/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
+++ b/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
@@ -12,24 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Hierarchy.ConCatExtensions
-  other-modules:
-      Paths_categorifier_concat_extensions_integration
-  autogen-modules:
-      Paths_categorifier_concat_extensions_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , base >=4.11.0 && <4.17
-    , bytestring >=0.10.9 && <0.12
-    , categorifier-category
-    , categorifier-concat-extensions-category
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
+    , base >=4.13.0 && <4.17
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -48,3 +35,21 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Hierarchy.ConCatExtensions
+  other-modules:
+      Paths_categorifier_concat_extensions_integration
+  autogen-modules:
+      Paths_categorifier_concat_extensions_integration
+  build-depends:
+    , bytestring >=0.10.9 && <0.12
+    , categorifier-category
+    , categorifier-concat-extensions-category
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , ghc-prim >=0.5.3 && <0.9
+    , transformers >=0.5.6 && <0.7

--- a/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
+++ b/integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,11 +45,11 @@ library
   autogen-modules:
       Paths_categorifier_concat_extensions_integration
   build-depends:
-    , bytestring >=0.10.9 && <0.12
+    , bytestring ^>=0.10.9 || ^>=0.11.0
     , categorifier-category
     , categorifier-concat-extensions-category
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/concat/examples/categorifier-concat-examples.cabal
+++ b/integrations/concat/examples/categorifier-concat-examples.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/concat/examples/categorifier-concat-examples.cabal
+++ b/integrations/concat/examples/categorifier-concat-examples.cabal
@@ -12,23 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.ConCat.Examples.Syntactic
-  other-modules:
-      Paths_categorifier_concat_examples
-  autogen-modules:
-      Paths_categorifier_concat_examples
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , bytestring >=0.10.9 && <0.12
-    , categorifier-category
-    , categorifier-client
-    , concat-examples
-    , ghc >=8.8.1 && <9.4
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -47,3 +35,20 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.ConCat.Examples.Syntactic
+  other-modules:
+      Paths_categorifier_concat_examples
+  autogen-modules:
+      Paths_categorifier_concat_examples
+  build-depends:
+    , bytestring >=0.10.9 && <0.12
+    , categorifier-category
+    , categorifier-client
+    , concat-examples
+    , ghc >=8.8.1 && <9.4
+    , ghc-prim >=0.5.3 && <0.9
+    , transformers >=0.5.6 && <0.7

--- a/integrations/concat/examples/categorifier-concat-examples.cabal
+++ b/integrations/concat/examples/categorifier-concat-examples.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,10 +45,10 @@ library
   autogen-modules:
       Paths_categorifier_concat_examples
   build-depends:
-    , bytestring >=0.10.9 && <0.12
+    , bytestring ^>=0.10.9 || ^>=0.11.0
     , categorifier-category
     , categorifier-client
     , concat-examples
-    , ghc >=8.8.1 && <9.4
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
+    , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
+++ b/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
@@ -12,19 +12,7 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
-  ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
-    -freduction-depth=0
-    -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.ConCat.Instances
-      Categorifier.Test.TotOrd
+common defaults
   build-depends:
     , base >=4.13.0 && <4.17
     , categorifier-category
@@ -32,7 +20,8 @@ library
     , categorifier-plugin-test
     , concat-classes
     , concat-examples
-    , constraints >=0.12 && <0.14
+  ghc-options:
+    -Wall
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -52,130 +41,67 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite concat-class-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.ConCat.Instances
+      Categorifier.Test.TotOrd
+  build-depends:
+    , constraints >=0.12 && <0.14
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: ConCat/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -fplugin-opt Categorifier:defer-failures
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.classHierarchy
     -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
     -- ConCat includes support for `index` and `tabulate`
     -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
-    -O0
   build-depends:
     , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
     , categorifier-adjunctions-integration
     , categorifier-adjunctions-integration-test
-    , categorifier-category
-    , categorifier-client
     , categorifier-concat-integration
     , categorifier-concat-integration-test
     , categorifier-hedgehog
     , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , concat-examples
     , either >=5.0.1 && <5.1
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
+
+test-suite concat-class-hierarchy
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: ConCat/Main.hs
+  ghc-options:
+    -O0
 
 test-suite concat-class-hierarchy-optimized
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: ConCat/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.classHierarchy
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -- ConCat includes support for `index` and `tabulate`
-    -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , base >=4.13.0 && <4.17
-    , categorifier-adjunctions-integration
-    , categorifier-adjunctions-integration-test
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-integration
-    , categorifier-concat-integration-test
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
 
 test-suite concat-function-hierarchy
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: ConCat/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -- ConCat includes support for `index` and `tabulate`
-    -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
     -O0
-  build-depends:
-    , base >=4.13.0 && <4.17
-    , categorifier-adjunctions-integration
-    , categorifier-adjunctions-integration-test
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-integration
-    , categorifier-concat-integration-test
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
 
 test-suite concat-function-hierarchy-optimized
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: ConCat/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -- ConCat includes support for `index` and `tabulate`
-    -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categorifier-adjunctions-integration
-    , categorifier-adjunctions-integration-test
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-integration
-    , categorifier-concat-integration-test
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
+++ b/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
@@ -14,7 +14,7 @@ source-repository head
 
 common defaults
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-category
     , categorifier-client
     , categorifier-plugin-test
@@ -47,7 +47,7 @@ library
       Categorifier.Test.ConCat.Instances
       Categorifier.Test.TotOrd
   build-depends:
-    , constraints >=0.12 && <0.14
+    , constraints ^>=0.12.0 || ^>=0.13.0
 
 common hierarchy-tests
   import: defaults
@@ -64,17 +64,17 @@ common hierarchy-tests
     -- ConCat includes support for `index` and `tabulate`
     -fplugin-opt Categorifier:maker-map:Categorifier.Adjunctions.Integration.makerMapFun
   build-depends:
-    , adjunctions >=4.4 && <4.5
+    , adjunctions ^>=4.4
     , categorifier-adjunctions-integration
     , categorifier-adjunctions-integration-test
     , categorifier-concat-integration
     , categorifier-concat-integration-test
     , categorifier-hedgehog
     , categorifier-plugin
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , either ^>=5.0.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite concat-class-hierarchy
   import: hierarchy-tests

--- a/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
+++ b/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
@@ -24,22 +24,22 @@ common defaults
     -Wall
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/concat/integration/categorifier-concat-integration.cabal
+++ b/integrations/concat/integration/categorifier-concat-integration.cabal
@@ -12,26 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Hierarchy.ConCat
-  other-modules:
-      Paths_categorifier_concat_integration
-  autogen-modules:
-      Paths_categorifier_concat_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , bytestring >=0.10.9 && <0.12
-    , categorifier-category
-    , categorifier-client
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , concat-classes
-    , ghc-prim >=0.5.3 && <0.9
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -50,3 +35,23 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Hierarchy.ConCat
+  other-modules:
+      Paths_categorifier_concat_integration
+  autogen-modules:
+      Paths_categorifier_concat_integration
+  build-depends:
+    , bytestring >=0.10.9 && <0.12
+    , categorifier-category
+    , categorifier-client
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , concat-classes
+    , ghc-prim >=0.5.3 && <0.9
+    , template-haskell >=2.15.0 && <2.19
+    , transformers >=0.5.6 && <0.7

--- a/integrations/concat/integration/categorifier-concat-integration.cabal
+++ b/integrations/concat/integration/categorifier-concat-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/concat/integration/categorifier-concat-integration.cabal
+++ b/integrations/concat/integration/categorifier-concat-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,13 +45,13 @@ library
   autogen-modules:
       Paths_categorifier_concat_integration
   build-depends:
-    , bytestring >=0.10.9 && <0.12
+    , bytestring ^>=0.10.9 || ^>=0.11.0
     , categorifier-category
     , categorifier-client
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
     , concat-classes
-    , ghc-prim >=0.5.3 && <0.9
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/fin/integration/categorifier-fin-integration.cabal
+++ b/integrations/fin/integration/categorifier-fin-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/fin/integration/categorifier-fin-integration.cabal
+++ b/integrations/fin/integration/categorifier-fin-integration.cabal
@@ -12,24 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Fin.Client
-  other-modules:
-      Paths_categorifier_fin_integration
-  autogen-modules:
-      Paths_categorifier_fin_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , base >=4.11.0 && <4.17
-    , categorifier-client
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , fin >=0.1.1 && <0.4
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
+    , base >=4.13.0 && <4.17
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -48,3 +35,21 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Fin.Client
+  other-modules:
+      Paths_categorifier_fin_integration
+  autogen-modules:
+      Paths_categorifier_fin_integration
+  build-depends:
+    , categorifier-client
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , containers >=0.6.2 && <0.7
+    , fin >=0.1.1 && <0.4
+    , template-haskell >=2.15.0 && <2.19
+    , transformers >=0.5.6 && <0.7

--- a/integrations/fin/integration/categorifier-fin-integration.cabal
+++ b/integrations/fin/integration/categorifier-fin-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -49,7 +49,7 @@ library
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , fin >=0.1.1 && <0.4
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
+    , containers ^>=0.6.2
+    , fin ^>=0.1.1 || ^>=0.2 || ^>=0.3
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/ghc-bignum/integration-test/Categorifier/Test/GhcBignum.hs
+++ b/integrations/ghc-bignum/integration-test/Categorifier/Test/GhcBignum.hs
@@ -19,7 +19,6 @@ import Categorifier.Test.HList (HMap1 (..))
 import Categorifier.Test.TH (mkBinaryTestConfig, mkUnaryTestConfig)
 import Categorifier.Test.Tests (TestTerms, insertTest)
 import Data.Proxy (Proxy (..))
-import GHC.Num.Integer (Integer)
 import qualified GHC.Num.Integer
 import GHC.Num.Natural (Natural)
 import qualified GHC.Num.Natural

--- a/integrations/ghc-bignum/integration-test/categorifier-ghc-bignum-integration-test.cabal
+++ b/integrations/ghc-bignum/integration-test/categorifier-ghc-bignum-integration-test.cabal
@@ -21,22 +21,22 @@ common defaults
     , constraints ^>=0.12.0 || ^>=0.13.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/ghc-bignum/integration-test/categorifier-ghc-bignum-integration-test.cabal
+++ b/integrations/ghc-bignum/integration-test/categorifier-ghc-bignum-integration-test.cabal
@@ -16,9 +16,9 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.15.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-plugin-test
-    , ghc-bignum >=1.0 && <1.4
+    , constraints ^>=0.12.0 || ^>=0.13.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -72,9 +72,9 @@ common hierarchy-tests
     , categorifier-ghc-bignum-integration-test
     , categorifier-plugin
     , concat-classes
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite ghc-bignum-hierarchy
   import: hierarchy-tests

--- a/integrations/ghc-bignum/integration-test/categorifier-ghc-bignum-integration-test.cabal
+++ b/integrations/ghc-bignum/integration-test/categorifier-ghc-bignum-integration-test.cabal
@@ -12,19 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
     -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.GhcBignum
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base >=4.15.0 && <4.17
     , categorifier-plugin-test
     , ghc-bignum >=1.0 && <1.4
   default-language: Haskell2010
@@ -46,12 +38,19 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite ghc-bignum-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.GhcBignum
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: GhcBignum/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -fplugin-opt Categorifier:defer-failures
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.classHierarchy
@@ -60,9 +59,7 @@ test-suite ghc-bignum-hierarchy
     -fplugin-opt Categorifier:lookup:Categorifier.Core.MakerMap.baseSymbolLookup
     -fplugin-opt Categorifier:maker-map:Categorifier.GhcBignum.Integration.makerMapFun
     -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -O0
   build-depends:
-    , base >=4.13.0 && <4.17
     , categorifier-category
     , categorifier-client
     , categorifier-concat-extensions-category
@@ -74,45 +71,22 @@ test-suite ghc-bignum-hierarchy
     , categorifier-ghc-bignum-integration
     , categorifier-ghc-bignum-integration-test
     , categorifier-plugin
-    , categorifier-plugin-test
     , concat-classes
-    , ghc-bignum >=1.0 && <1.4
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
 
-test-suite ghc-bignum-hierarchy-optimized
-  import: options
+test-suite ghc-bignum-hierarchy
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: GhcBignum/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.classHierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
-    -fplugin-opt Categorifier:lookup:Categorifier.GhcBignum.Integration.symbolLookup
-    -fplugin-opt Categorifier:lookup:Categorifier.Core.MakerMap.baseSymbolLookup
-    -fplugin-opt Categorifier:maker-map:Categorifier.GhcBignum.Integration.makerMapFun
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
+    -O0
+
+test-suite ghc-bignum-hierarchy-optimized
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: GhcBignum/Main.hs
+  ghc-options:
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-extensions-category
-    , categorifier-concat-extensions-integration
-    , categorifier-concat-extensions-integration-test
-    , categorifier-concat-integration
-    , categorifier-concat-integration-test
-    , categorifier-hedgehog
-    , categorifier-ghc-bignum-integration
-    , categorifier-ghc-bignum-integration-test
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , ghc-bignum >=1.0 && <1.4
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/ghc-bignum/integration/categorifier-ghc-bignum-integration.cabal
+++ b/integrations/ghc-bignum/integration/categorifier-ghc-bignum-integration.cabal
@@ -16,23 +16,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.GhcBignum.Integration
-  other-modules:
-      Paths_categorifier_ghc_bignum_integration
-  autogen-modules:
-      Paths_categorifier_ghc_bignum_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
-    , categorifier-client
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , ghc-bignum >=1.0 && <1.4
-    , template-haskell >=2.15.0 && <2.19
+    , base >=4.15.0 && <4.17
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -51,3 +39,20 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.GhcBignum.Integration
+  other-modules:
+      Paths_categorifier_ghc_bignum_integration
+  autogen-modules:
+      Paths_categorifier_ghc_bignum_integration
+  build-depends:
+    , categorifier-client
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , containers >=0.6.2 && <0.7
+    , ghc-bignum >=1.0 && <1.4
+    , template-haskell >=2.15.0 && <2.19

--- a/integrations/ghc-bignum/integration/categorifier-ghc-bignum-integration.cabal
+++ b/integrations/ghc-bignum/integration/categorifier-ghc-bignum-integration.cabal
@@ -23,22 +23,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/ghc-bignum/integration/categorifier-ghc-bignum-integration.cabal
+++ b/integrations/ghc-bignum/integration/categorifier-ghc-bignum-integration.cabal
@@ -20,7 +20,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.15.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -53,6 +53,6 @@ library
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , ghc-bignum >=1.0 && <1.4
-    , template-haskell >=2.15.0 && <2.19
+    , containers ^>=0.6.2
+    , constraints ^>=0.12.0 || ^>=0.13.0
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0

--- a/integrations/linear-base/integration-test/Categorifier/Test/LinearBase.hs
+++ b/integrations/linear-base/integration-test/Categorifier/Test/LinearBase.hs
@@ -15,9 +15,8 @@ module Categorifier.Test.LinearBase
   )
 where
 
-import Categorifier.Test.Data (Pair (..))
 import Categorifier.Test.HList (HMap1 (..))
-import Categorifier.Test.TH (mkBinaryTestConfig, mkExprTest, mkUnaryTestConfig)
+import Categorifier.Test.TH (mkBinaryTestConfig, mkUnaryTestConfig)
 import Categorifier.Test.Tests (TestTerms, insertTest)
 import qualified Control.Functor.Linear
 import qualified Data.Array.Mutable.Linear
@@ -32,16 +31,9 @@ import qualified Data.Num.Linear
 import qualified Data.Ord.Linear
 import Data.Proxy (Proxy (..))
 import qualified Data.Replicator.Linear
-import qualified Data.Replicator.Linear.Internal
-import qualified Data.Replicator.Linear.Internal.ReplicationStream
 import Data.Semigroup (Sum (..))
 import qualified Data.Tuple.Linear
 import qualified Data.V.Linear
-import qualified Data.V.Linear.Internal
-import qualified Data.Vector as Vector
-import GHC.Int (Int16, Int32, Int64, Int8)
-import GHC.TypeLits (KnownNat)
-import GHC.Word (Word16, Word32, Word64, Word8)
 import qualified Prelude.Linear
 import qualified Unsafe.Linear
 

--- a/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
+++ b/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
@@ -16,10 +16,10 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.15.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-plugin-test
-    , linear-base >=0.3.0 && <0.4
-    , pointed >=5.0.0 && <5.1
+    , linear-base ^>=0.3.0
+    , pointed ^>=5.0.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -73,10 +73,10 @@ common hierarchy-tests
     , categorifier-linear-base-integration-test
     , categorifier-plugin
     , concat-classes
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , either ^>=5.0.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite linear-base-hierarchy
   import: hierarchy-tests

--- a/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
+++ b/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
@@ -12,23 +12,14 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
     -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.LinearBase
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base >=4.15.0 && <4.17
     , categorifier-plugin-test
     , linear-base >=0.3.0 && <0.4
     , pointed >=5.0.0 && <5.1
-    , vector >=0.12.2 && <0.14
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -48,12 +39,19 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite linear-base-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.LinearBase
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: LinearBase/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -fplugin-opt Categorifier:defer-failures
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.classHierarchy
@@ -62,9 +60,7 @@ test-suite linear-base-hierarchy
     -fplugin-opt Categorifier:lookup:Categorifier.Core.MakerMap.baseSymbolLookup
     -fplugin-opt Categorifier:maker-map:Categorifier.LinearBase.Integration.makerMapFun
     -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -O0
   build-depends:
-    , base >=4.13.0 && <4.17
     , categorifier-category
     , categorifier-client
     , categorifier-concat-extensions-category
@@ -76,49 +72,23 @@ test-suite linear-base-hierarchy
     , categorifier-linear-base-integration
     , categorifier-linear-base-integration-test
     , categorifier-plugin
-    , categorifier-plugin-test
     , concat-classes
     , either >=5.0.1 && <5.1
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
-    , linear-base >=0.3.0 && <0.4
-    , pointed >=5.0.0 && <5.1
     , template-haskell >=2.15.0 && <2.19
 
-test-suite linear-base-hierarchy-optimized
-  import: options
+test-suite linear-base-hierarchy
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: LinearBase/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.classHierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
-    -fplugin-opt Categorifier:lookup:Categorifier.LinearBase.Integration.symbolLookup
-    -fplugin-opt Categorifier:lookup:Categorifier.Core.MakerMap.baseSymbolLookup
-    -fplugin-opt Categorifier:maker-map:Categorifier.LinearBase.Integration.makerMapFun
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
+    -O0
+
+test-suite linear-base-hierarchy-optimized
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: LinearBase/Main.hs
+  ghc-options:
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-extensions-category
-    , categorifier-concat-extensions-integration
-    , categorifier-concat-extensions-integration-test
-    , categorifier-concat-integration
-    , categorifier-concat-integration-test
-    , categorifier-hedgehog
-    , categorifier-linear-base-integration
-    , categorifier-linear-base-integration-test
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , concat-classes
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , linear-base >=0.3.0 && <0.4
-    , pointed >=5.0.0 && <5.1
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
+++ b/integrations/linear-base/integration-test/categorifier-linear-base-integration-test.cabal
@@ -16,28 +16,28 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
-    , categorifier-plugin-test
-    , linear-base ^>=0.3.0
-    , pointed ^>=5.0.0
+    base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0,
+    categorifier-plugin-test,
+    linear-base ^>=0.3.0,
+    pointed ^>=5.0.0,
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
+++ b/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
+++ b/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
@@ -12,25 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.LinearBase.Client
-      Categorifier.LinearBase.Integration
-  other-modules:
-      Paths_categorifier_linear_base_integration
-  autogen-modules:
-      Paths_categorifier_linear_base_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
-    , categorifier-client
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , linear-base >=0.3.0 && <0.4
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
+    , base >=4.15.0 && <4.17
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -49,3 +35,22 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.LinearBase.Client
+      Categorifier.LinearBase.Integration
+  other-modules:
+      Paths_categorifier_linear_base_integration
+  autogen-modules:
+      Paths_categorifier_linear_base_integration
+  build-depends:
+    , categorifier-client
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , containers >=0.6.2 && <0.7
+    , linear-base >=0.3.0 && <0.4
+    , template-haskell >=2.15.0 && <2.19
+    , transformers >=0.5.6 && <0.7

--- a/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
+++ b/integrations/linear-base/integration/categorifier-linear-base-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.15.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -50,7 +50,9 @@ library
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , linear-base >=0.3.0 && <0.4
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
+    , containers ^>=0.6.2
+    -- NB: This requires a newer release than `categorifier-plugin` because it relies on type class
+    -- instances that didn’t exist prior to 0.3.0.
+    , linear-base ^>=0.3.0
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/unconcat/category/categorifier-unconcat-category.cabal
+++ b/integrations/unconcat/category/categorifier-unconcat-category.cabal
@@ -22,22 +22,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/unconcat/category/categorifier-unconcat-category.cabal
+++ b/integrations/unconcat/category/categorifier-unconcat-category.cabal
@@ -15,15 +15,8 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.UnconCat
-  other-modules:
-      Paths_categorifier_unconcat_category
-  autogen-modules:
-      Paths_categorifier_unconcat_category
+common defaults
   ghc-options:
-    -O2
     -Wall
   build-depends:
     , base >=4.13.0 && <4.17
@@ -45,3 +38,14 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.UnconCat
+  other-modules:
+      Paths_categorifier_unconcat_category
+  autogen-modules:
+      Paths_categorifier_unconcat_category
+  ghc-options:
+    -O2

--- a/integrations/unconcat/category/categorifier-unconcat-category.cabal
+++ b/integrations/unconcat/category/categorifier-unconcat-category.cabal
@@ -19,7 +19,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs

--- a/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
+++ b/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
@@ -23,22 +23,22 @@ common defaults
     -Wall
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
+++ b/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
@@ -12,23 +12,15 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
-  ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
-    -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.UnconCat.Instances
+common defaults
   build-depends:
     , base >=4.13.0 && <4.17
     , categorifier-concat-integration-test
-    , categorifier-unconcat-category
     , categorifier-plugin-test
+    , categorifier-unconcat-category
     , concat-classes
+  ghc-options:
+    -Wall
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -48,63 +40,48 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite unconcat-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.UnconCat.Instances
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: UnconCat/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.UnconCat.hierarchy
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
-    -O0
   build-depends:
     , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
     , categorifier-category
     , categorifier-client
     , categorifier-concat-integration
-    , categorifier-concat-integration-test
     , categorifier-hedgehog
     , categorifier-plugin
-    , categorifier-plugin-test
-    , categorifier-unconcat-category
     , categorifier-unconcat-integration
     , categorifier-unconcat-integration-test
-    , concat-classes
     , concat-examples
     , either >=5.0.1 && <5.1
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
 
-test-suite unconcat-hierarchy-optimized
-  import: options
+test-suite unconcat-hierarchy
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: UnconCat/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.UnconCat.hierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
+    -O0
+
+test-suite unconcat-hierarchy-optimized
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: UnconCat/Main.hs
+  ghc-options:
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-concat-integration
-    , categorifier-concat-integration-test
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , categorifier-unconcat-category
-    , categorifier-unconcat-integration
-    , categorifier-unconcat-integration-test
-    , concat-classes
-    , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
+++ b/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
@@ -14,7 +14,7 @@ source-repository head
 
 common defaults
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-concat-integration-test
     , categorifier-plugin-test
     , categorifier-unconcat-category
@@ -57,7 +57,7 @@ common hierarchy-tests
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.UnconCat.hierarchy
     -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
   build-depends:
-    , adjunctions >=4.4 && <4.5
+    , adjunctions ^>=4.4
     , categorifier-category
     , categorifier-client
     , categorifier-concat-integration
@@ -66,10 +66,10 @@ common hierarchy-tests
     , categorifier-unconcat-integration
     , categorifier-unconcat-integration-test
     , concat-examples
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , either ^>=5.0.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite unconcat-hierarchy
   import: hierarchy-tests

--- a/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
+++ b/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
+++ b/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
@@ -12,23 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Hierarchy.UnconCat
-  other-modules:
-      Paths_categorifier_unconcat_integration
-  autogen-modules:
-      Paths_categorifier_unconcat_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
     , base >=4.13.0 && <4.17
-    , bytestring >=0.10.9 && <0.12
-    , categorifier-duoids
-    , categorifier-plugin
-    , categorifier-unconcat-category
-    , ghc >=8.8.1 && <9.4
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -47,3 +35,20 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Hierarchy.UnconCat
+  other-modules:
+      Paths_categorifier_unconcat_integration
+  autogen-modules:
+      Paths_categorifier_unconcat_integration
+  build-depends:
+    , bytestring >=0.10.9 && <0.12
+    , categorifier-duoids
+    , categorifier-plugin
+    , categorifier-unconcat-category
+    , ghc >=8.8.1 && <9.4
+    , ghc-prim >=0.5.3 && <0.9
+    , transformers >=0.5.6 && <0.7

--- a/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
+++ b/integrations/unconcat/integration/categorifier-unconcat-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,10 +45,10 @@ library
   autogen-modules:
       Paths_categorifier_unconcat_integration
   build-depends:
-    , bytestring >=0.10.9 && <0.12
+    , bytestring ^>=0.10.9 || ^>=0.11.0
     , categorifier-duoids
     , categorifier-plugin
     , categorifier-unconcat-category
-    , ghc >=8.8.1 && <9.4
-    , ghc-prim >=0.5.3 && <0.9
-    , transformers >=0.5.6 && <0.7
+    , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/vec/integration-test/Categorifier/Test/Vec.hs
+++ b/integrations/vec/integration-test/Categorifier/Test/Vec.hs
@@ -11,7 +11,7 @@ module Categorifier.Test.Vec
 where
 
 import Categorifier.Test.HList (HMap1 (..))
-import Categorifier.Test.TH (mkBinaryTestConfig, mkExprTest, mkUnaryTestConfig)
+import Categorifier.Test.TH (mkBinaryTestConfig, mkUnaryTestConfig)
 import Categorifier.Test.Tests (TestTerms, insertTest)
 import Data.Fin (Fin)
 import Data.Proxy (Proxy (..))

--- a/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
+++ b/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
@@ -12,23 +12,13 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
     -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.Vec
-      Categorifier.Test.Vec.Instances
   build-depends:
     , base >=4.11.0 && <4.17
     , categorifier-plugin-test
     , fin >=0.1.1 && <0.4
-    , pointed >=5.0.0 && <5.1
     , vec >=0.3 && <0.6
   default-language: Haskell2010
   default-extensions:
@@ -49,12 +39,22 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
-test-suite vec-hierarchy
-  import: options
-  type: exitcode-stdio-1.0
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.Vec
+      Categorifier.Test.Vec.Instances
+  build-depends:
+    , pointed >=5.0.0 && <5.1
+
+common hierarchy-tests
+  import: defaults
   hs-source-dirs: test
-  main-is: Vec/Main.hs
   ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
     -fplugin Categorifier
     -- Using the ConCat hierarchy, because it's the only one that supports `traverse` (and probably
     -- other things)
@@ -63,9 +63,7 @@ test-suite vec-hierarchy
     -fplugin-opt Categorifier:lookup:Categorifier.Vec.Integration.symbolLookup
     -fplugin-opt Categorifier:maker-map:Categorifier.Vec.Integration.makerMapFun
     -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
-    -O0
   build-depends:
-    , base >=4.11.0 && <4.17
     , categorifier-concat-integration
     , categorifier-concat-extensions-category
     , categorifier-concat-extensions-integration
@@ -78,44 +76,21 @@ test-suite vec-hierarchy
     , categorifier-vec-integration
     , categorifier-vec-integration-test
     , concat-classes
-    , fin >=0.1.1 && <0.4
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
-    , vec >=0.3 && <0.6
+
+test-suite vec-hierarchy
+  import: hierarchy-tests
+  type: exitcode-stdio-1.0
+  main-is: Vec/Main.hs
+  ghc-options:
+    -O0
 
 test-suite vec-hierarchy-optimized
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: Vec/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -- Using the ConCat hierarchy, because it's the only one that supports `traverse` (and probably
-    -- other things)
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCat.functionHierarchy
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.ConCatExtensions.hierarchy
-    -fplugin-opt Categorifier:lookup:Categorifier.Vec.Integration.symbolLookup
-    -fplugin-opt Categorifier:maker-map:Categorifier.Vec.Integration.makerMapFun
-    -fplugin-opt Categorifier:maker-map:Categorifier.Core.MakerMap.baseMakerMapFun
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , base >=4.11.0 && <4.17
-    , categorifier-concat-integration
-    , categorifier-concat-extensions-category
-    , categorifier-concat-extensions-integration
-    , categorifier-concat-extensions-integration-test
-    , categorifier-category
-    , categorifier-client
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , categorifier-vec-integration
-    , categorifier-vec-integration-test
-    , concat-classes
-    , fin >=0.1.1 && <0.4
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
-    , vec >=0.3 && <0.6

--- a/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
+++ b/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
@@ -22,22 +22,22 @@ common defaults
     , vec ^>=0.3 || ^>=0.4 || ^>=0.5
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
+++ b/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
@@ -16,10 +16,10 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.11.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-plugin-test
-    , fin >=0.1.1 && <0.4
-    , vec >=0.3 && <0.6
+    , fin ^>=0.1.1 || ^>=0.2 || ^>=0.3
+    , vec ^>=0.3 || ^>=0.4 || ^>=0.5
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -45,7 +45,7 @@ library
       Categorifier.Test.Vec
       Categorifier.Test.Vec.Instances
   build-depends:
-    , pointed >=5.0.0 && <5.1
+    , pointed ^>=5.0.0
 
 common hierarchy-tests
   import: defaults
@@ -76,9 +76,9 @@ common hierarchy-tests
     , categorifier-vec-integration
     , categorifier-vec-integration-test
     , concat-classes
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
 
 test-suite vec-hierarchy
   import: hierarchy-tests

--- a/integrations/vec/integration/categorifier-vec-integration.cabal
+++ b/integrations/vec/integration/categorifier-vec-integration.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/integrations/vec/integration/categorifier-vec-integration.cabal
+++ b/integrations/vec/integration/categorifier-vec-integration.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -50,7 +50,7 @@ library
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
-    , vec >=0.3 && <0.6
+    , containers ^>=0.6.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , transformers ^>=0.5.6 || ^>=0.6.0
+    , vec ^>=0.3 || ^>=0.4 || ^>=0.5

--- a/integrations/vec/integration/categorifier-vec-integration.cabal
+++ b/integrations/vec/integration/categorifier-vec-integration.cabal
@@ -12,25 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.Vec.Client
-      Categorifier.Vec.Integration
-  other-modules:
-      Paths_categorifier_vec_integration
-  autogen-modules:
-      Paths_categorifier_vec_integration
-  ghc-options: -Wall
+common defaults
+  ghc-options:
+    -Wall
   build-depends:
-    , base >=4.11.0 && <4.17
-    , categorifier-client
-    , categorifier-duoids
-    , categorifier-ghc
-    , categorifier-plugin
-    , containers >=0.6.2 && <0.7
-    , template-haskell >=2.15.0 && <2.19
-    , transformers >=0.5.6 && <0.7
-    , vec >=0.3 && <0.6
+    , base >=4.13.0 && <4.17
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -49,3 +35,22 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Vec.Client
+      Categorifier.Vec.Integration
+  other-modules:
+      Paths_categorifier_vec_integration
+  autogen-modules:
+      Paths_categorifier_vec_integration
+  build-depends:
+    , categorifier-client
+    , categorifier-duoids
+    , categorifier-ghc
+    , categorifier-plugin
+    , containers >=0.6.2 && <0.7
+    , template-haskell >=2.15.0 && <2.19
+    , transformers >=0.5.6 && <0.7
+    , vec >=0.3 && <0.6

--- a/plugin-test/categorifier-plugin-test.cabal
+++ b/plugin-test/categorifier-plugin-test.cabal
@@ -16,16 +16,16 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
+    , adjunctions ^>=4.4
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
     , categorifier-category
     , categorifier-client
     , categorifier-common
     , categorifier-hedgehog
     , categorifier-plugin
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -61,21 +61,21 @@ library
   ghc-options:
     -O2
   build-depends:
-    , PyF >=0.9.0 && <0.12
-    , distributive >=0.6.2 && <0.7
-    , extra >=1.7.8 && <1.8
-    , fin >=0.1.1 && <0.4
-    , text >=1.2.4 && <1.3
-    , vec >=0.3 && <0.6
+    , PyF ^>=0.9.0 || ^>=0.10.0 || ^>=0.11.0
+    , distributive ^>=0.6.2
+    , extra ^>=1.7.8
+    , fin ^>=0.1.1 || ^>=0.2 || ^>=0.3
+    , text ^>=1.2.4
+    , vec ^>=0.3 || ^>=0.4 || ^>=0.5
   if impl(ghc >= 9.0.0)
-    build-depends: linear-base >=0.2.0 && <0.4
+    build-depends: linear-base ^>=0.2.0 || ^>=0.3.0
 
 common tests
   import: defaults
   hs-source-dirs: test
   build-depends:
     , categorifier-plugin-test
-    , either >=5.0.1 && <5.1
+    , either ^>=5.0.1
   ghc-options:
     -- make it possible to inline almost anything
     -fexpose-all-unfoldings

--- a/plugin-test/categorifier-plugin-test.cabal
+++ b/plugin-test/categorifier-plugin-test.cabal
@@ -12,31 +12,10 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-common options
+common defaults
   ghc-options:
-    -- make it possible to inline almost anything
-    -fexpose-all-unfoldings
-    -- ensure unfoldings are available
-    -fno-omit-interface-pragmas
-    -Wall
-
-library
-  exposed-modules:
-      Categorifier.Test.Data
-      Categorifier.Test.HList
-      Categorifier.Test.Hask
-      Categorifier.Test.Term
-      Categorifier.Test.Tests
-      Categorifier.Test.TH
-  other-modules:
-      Paths_categorifier_plugin_test
-  autogen-modules:
-      Paths_categorifier_plugin_test
-  ghc-options:
-    -O2
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.12
     , adjunctions >=4.4 && <4.5
     , base >=4.13.0 && <4.17
     , categorifier-category
@@ -44,16 +23,9 @@ library
     , categorifier-common
     , categorifier-hedgehog
     , categorifier-plugin
-    , distributive >=0.6.2 && <0.7
-    , extra >=1.7.8 && <1.8
-    , fin >=0.1.1 && <0.4
     , ghc-prim >=0.5.3 && <0.9
     , hedgehog >=1.0.3 && <1.3
     , template-haskell >=2.15.0 && <2.19
-    , text >=1.2.4 && <1.3
-    , vec >=0.3 && <0.6
-  if impl(ghc >= 9.0.0)
-    build-depends: linear-base >=0.2.0 && <0.4
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -73,72 +45,69 @@ library
     , DeriveTraversable
     , DerivingStrategies
 
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.Test.Data
+      Categorifier.Test.HList
+      Categorifier.Test.Hask
+      Categorifier.Test.Term
+      Categorifier.Test.Tests
+      Categorifier.Test.TH
+  other-modules:
+      Paths_categorifier_plugin_test
+  autogen-modules:
+      Paths_categorifier_plugin_test
+  ghc-options:
+    -O2
+  build-depends:
+    , PyF >=0.9.0 && <0.12
+    , distributive >=0.6.2 && <0.7
+    , extra >=1.7.8 && <1.8
+    , fin >=0.1.1 && <0.4
+    , text >=1.2.4 && <1.3
+    , vec >=0.3 && <0.6
+  if impl(ghc >= 9.0.0)
+    build-depends: linear-base >=0.2.0 && <0.4
+
+common tests
+  import: defaults
+  hs-source-dirs: test
+  build-depends:
+    , categorifier-plugin-test
+    , either >=5.0.1 && <5.1
+  ghc-options:
+    -- make it possible to inline almost anything
+    -fexpose-all-unfoldings
+    -- ensure unfoldings are available
+    -fno-omit-interface-pragmas
+    -fplugin Categorifier
+    -fplugin-opt Categorifier:defer-failures
+
 -- run without any explicit integration (uses only bits from base
 test-suite default-plugin
-  import: options
+  import: tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: Base/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
     -O0
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
+
+common hierarchy-tests
+  import: tests
+  ghc-options:
+    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.baseHierarchy
 
 test-suite base-hierarchy
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: Base/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.baseHierarchy
     -O0
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19
 
 test-suite base-hierarchy-optimized
-  import: options
+  import: hierarchy-tests
   type: exitcode-stdio-1.0
-  hs-source-dirs: test
   main-is: Base/Main.hs
   ghc-options:
-    -fplugin Categorifier
-    -fplugin-opt Categorifier:defer-failures
-    -fplugin-opt Categorifier:hierarchy:Categorifier.Hierarchy.baseHierarchy
     -O2
     -fignore-interface-pragmas
-  build-depends:
-    , adjunctions >=4.4 && <4.5
-    , base >=4.13.0 && <4.17
-    , categorifier-category
-    , categorifier-client
-    , categorifier-hedgehog
-    , categorifier-plugin
-    , categorifier-plugin-test
-    , either >=5.0.1 && <5.1
-    , ghc-prim >=0.5.3 && <0.9
-    , hedgehog >=1.0.3 && <1.3
-    , template-haskell >=2.15.0 && <2.19

--- a/plugin-test/categorifier-plugin-test.cabal
+++ b/plugin-test/categorifier-plugin-test.cabal
@@ -28,22 +28,22 @@ common defaults
     , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/plugin/categorifier-plugin.cabal
+++ b/plugin/categorifier-plugin.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/plugin/categorifier-plugin.cabal
+++ b/plugin/categorifier-plugin.cabal
@@ -5,6 +5,7 @@ version:        0.1
 description:    GHC plugin for Compiling to Categories
 homepage:       https://github.com/con-kitty/categorifier#readme
 bug-reports:    https://github.com/con-kitty/categorifier/issues
+extra-doc-files: README.md
 build-type:     Simple
 tested-with:    GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2, GHC==9.2.8
 

--- a/plugin/categorifier-plugin.cabal
+++ b/plugin/categorifier-plugin.cabal
@@ -12,7 +12,32 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
+common defaults
+  ghc-options:
+    -Wall
+  build-depends:
+    , base >=4.13.0 && <4.17
+  default-language: Haskell2010
+  default-extensions:
+      InstanceSigs
+    , ScopedTypeVariables
+    , TypeApplications
+    , FlexibleContexts
+    , FlexibleInstances
+    , FunctionalDependencies
+    , LambdaCase
+    , TypeOperators
+    , BangPatterns
+    , StandaloneDeriving
+    , DeriveGeneric
+    , DeriveDataTypeable
+    , DeriveFunctor
+    , DeriveFoldable
+    , DeriveTraversable
+    , DerivingStrategies
+
 library
+  import: defaults
   exposed-modules:
       Categorifier
       -- __NB__: Only public for runtime lookup
@@ -42,11 +67,9 @@ library
   ghc-options:
     -O2
     -fignore-interface-pragmas
-    -Wall
   build-depends:
     , PyF >=0.9.0 && <0.12
     , barbies >=2.0.1 && <2.1
-    , base >=4.13.0 && <4.17
     , bytestring >=0.10.9 && <0.12
     , categorifier-category
     , categorifier-client
@@ -68,21 +91,3 @@ library
     , transformers >=0.5.6 && <0.7
     , uniplate >=1.6.13 && <1.7
     , yaya >=0.3.2 && <0.5
-  default-language: Haskell2010
-  default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies

--- a/plugin/categorifier-plugin.cabal
+++ b/plugin/categorifier-plugin.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -68,26 +68,26 @@ library
     -O2
     -fignore-interface-pragmas
   build-depends:
-    , PyF >=0.9.0 && <0.12
-    , barbies >=2.0.1 && <2.1
-    , bytestring >=0.10.9 && <0.12
+    , PyF ^>=0.9.0 || ^>=0.10.0 || ^>=0.11.0
+    , barbies ^>=2.0.1
+    , bytestring ^>=0.10.9 || ^>=0.11.0
     , categorifier-category
     , categorifier-client
     , categorifier-common
     , categorifier-duoids
     , categorifier-ghc
     , categorifier-th
-    , containers >=0.6.2 && <0.7
-    , either >=5.0.1 && <5.1
-    , extra >=1.7.8 && <1.8
-    , ghc >=8.8.1 && <9.4
-    , ghc-prim >=0.5.3 && <0.9
-    , semialign >=1.1.0 && <1.4
-    , semigroupoids >=5.3.4 && <5.4
-    , syb >=0.7.1 && <0.8
-    , template-haskell >=2.15.0 && <2.19
-    , text >=1.2.4 && <1.3
-    , these >=1.1.1 && <1.3
-    , transformers >=0.5.6 && <0.7
-    , uniplate >=1.6.13 && <1.7
-    , yaya >=0.3.2 && <0.5
+    , containers ^>=0.6.2
+    , either ^>=5.0.1
+    , extra ^>=1.7.8
+    , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , semialign ^>=1.1 || ^>=1.2 || ^>=1.3
+    , semigroupoids ^>=5.3.4
+    , syb ^>=0.7.1
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , text ^>=1.2.4
+    , these ^>=1.1.1 || ^>=1.2
+    , transformers ^>=0.5.6 || ^>=0.6.0
+    , uniplate ^>=1.6.13
+    , yaya ^>=0.3.2 || ^>=0.4.0

--- a/th/categorifier-th.cabal
+++ b/th/categorifier-th.cabal
@@ -19,22 +19,22 @@ common defaults
     , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
-      InstanceSigs
-    , ScopedTypeVariables
-    , TypeApplications
-    , FlexibleContexts
-    , FlexibleInstances
-    , FunctionalDependencies
-    , LambdaCase
-    , TypeOperators
-    , BangPatterns
-    , StandaloneDeriving
-    , DeriveGeneric
-    , DeriveDataTypeable
-    , DeriveFunctor
-    , DeriveFoldable
-    , DeriveTraversable
-    , DerivingStrategies
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
 
 library
   import: defaults

--- a/th/categorifier-th.cabal
+++ b/th/categorifier-th.cabal
@@ -16,7 +16,7 @@ common defaults
   ghc-options:
     -Wall
   build-depends:
-    , base >=4.13.0 && <4.17
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -47,11 +47,11 @@ library
     -O2
     -fignore-interface-pragmas
   build-depends:
-    , PyF >=0.9.0 && <0.12
+    , PyF ^>=0.9.0 || ^>=0.10.0 || ^>=0.11.0
     , categorifier-common
     , categorifier-duoids
-    , containers >=0.6.2 && <0.7
-    , semialign >=1.1.0 && <1.4
-    , template-haskell >=2.15.0 && <2.19
-    , these >=1.1.1 && <1.3
-    , transformers >=0.5.6 && <0.7
+    , containers ^>=0.6.2
+    , semialign ^>=1.1 || ^>=1.2 || ^>=1.3
+    , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0
+    , these ^>=1.1.1 || ^>=1.2
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/th/categorifier-th.cabal
+++ b/th/categorifier-th.cabal
@@ -12,26 +12,11 @@ source-repository head
   type: git
   location: https://github.com/con-kitty/categorifier
 
-library
-  exposed-modules:
-      Categorifier.TH
-      Paths_categorifier_th
-  autogen-modules:
-      Paths_categorifier_th
+common defaults
   ghc-options:
-    -O2
-    -fignore-interface-pragmas
     -Wall
   build-depends:
-    , PyF >=0.9.0 && <0.12
     , base >=4.13.0 && <4.17
-    , categorifier-common
-    , categorifier-duoids
-    , containers >=0.6.2 && <0.7
-    , semialign >=1.1.0 && <1.4
-    , template-haskell >=2.15.0 && <2.19
-    , these >=1.1.1 && <1.3
-    , transformers >=0.5.6 && <0.7
   default-language: Haskell2010
   default-extensions:
       InstanceSigs
@@ -50,3 +35,23 @@ library
     , DeriveFoldable
     , DeriveTraversable
     , DerivingStrategies
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.TH
+      Paths_categorifier_th
+  autogen-modules:
+      Paths_categorifier_th
+  ghc-options:
+    -O2
+    -fignore-interface-pragmas
+  build-depends:
+    , PyF >=0.9.0 && <0.12
+    , categorifier-common
+    , categorifier-duoids
+    , containers >=0.6.2 && <0.7
+    , semialign >=1.1.0 && <1.4
+    , template-haskell >=2.15.0 && <2.19
+    , these >=1.1.1 && <1.3
+    , transformers >=0.5.6 && <0.7


### PR DESCRIPTION
This takes advantage of some newer features (e.g., `source-repository-package` can now list multiple subdirs) and makes some other improvements.

There is unfortunately still a lot of duplication. Cabal 3.8 supports multiple public libraries in a package, which can help a bit, but `cabal2nix` doesn’t yet handle that (NixOS/cabal2nix#448). Alternatively, something like [hpack-dhall](https://github.com/cabalism/hpack-dhall) would help a lot, but in general, I’ve tried to avoid any preprocessing in order to get Cabal to build things outside of Nix.

It’s probably easiest to review this PR commit-by-commit.