### PR TITLE
Extend `concat-examples` support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -37,6 +37,7 @@ packages:
   ./integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
   ./integrations/fin/integration/categorifier-fin-integration.cabal
   ./integrations/unconcat/category/categorifier-unconcat-category.cabal
+  ./integrations/unconcat/examples/categorifier-unconcat-examples.cabal
   ./integrations/unconcat/integration/categorifier-unconcat-integration.cabal
   ./integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
   ./integrations/vec/integration/categorifier-vec-integration.cabal

--- a/cabal.project
+++ b/cabal.project
@@ -32,6 +32,7 @@ packages:
   ./integrations/concat/integration/categorifier-concat-integration.cabal
   ./integrations/concat/integration-test/categorifier-concat-integration-test.cabal
   ./integrations/concat-extensions/category/categorifier-concat-extensions-category.cabal
+  ./integrations/concat-extensions/examples/categorifier-concat-extensions-examples.cabal
   ./integrations/concat-extensions/integration/categorifier-concat-extensions-integration.cabal
   ./integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
   ./integrations/fin/integration/categorifier-fin-integration.cabal

--- a/integrations/concat-extensions/examples/Categorifier/ConCatExtensions/Examples/Syntactic.hs
+++ b/integrations/concat-extensions/examples/Categorifier/ConCatExtensions/Examples/Syntactic.hs
@@ -1,0 +1,88 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | This is intended to be used /instead/ of "ConCat.Syntactic" when using the "Categorifier"
+--   plugin with `Categorifier.Hierarchy.ConCatExtensions.hierarchy`.
+--
+--   It re-exports the original module, adding instances for classes required by `Categorifier`.
+module Categorifier.ConCatExtensions.Examples.Syntactic
+  ( module Categorifier.ConCat.Examples.Syntactic,
+  )
+where
+
+import Categorifier.ConCat.Examples.Syntactic
+import qualified Categorifier.ConCatExtensions as Cat
+
+instance Cat.OrdCat' Syn a where
+  compareK = app0 "compare"
+
+instance Cat.LaxMonoidalFunctorCat Syn f where
+  liftA2K = app1 "liftA2"
+
+instance Cat.ApplicativeCat Syn f where
+  apK = app0 "<*>"
+
+-- TODO: Remove `Functor` constraint from upstream class
+instance (Functor h) => Cat.MonadCat Syn h where
+  joinK = app0 "join"
+  mmapK = app1 "=<<"
+
+-- TODO: Remove `Functor` constraint from upstream class
+instance (Functor h) => Cat.BindableCat Syn h where
+  bindK = app0 ">>="
+
+instance Cat.TraversableCat' Syn t f where
+  traverseK = app1 "traverse"
+
+instance Cat.NumCat' Syn a where
+  absK = app0 "abs"
+  signumK = app0 "signum"
+
+instance Cat.IntegralCat' Syn a where
+  evenK = app0 "even"
+  oddK = app0 "odd"
+  quotK = app0 "quot"
+  remK = app0 "rem"
+
+instance Cat.FloatingCat' Syn a where
+  powK = app0 "**"
+
+instance Cat.PowICat Syn a where
+  powIK = app1 "powI" . app0 . show . toInteger
+
+instance Cat.SemigroupCat Syn m where
+  appendK = app0 "<>"
+
+instance Cat.FixedCat Syn where
+  fixK = app1 "fix"
+
+instance Cat.RealToFracCat Syn a b where
+  realToFracK = app0 "realToFrac"
+
+instance Cat.FloatingPointConvertCat Syn where
+  floatToDoubleK = app0 "float2Double"
+  doubleToFloatK = app0 "double2Float"
+
+instance Cat.FloatingPointClassifyCat Syn a where
+  isNegativeZeroK = app0 "isNegativeZero"
+  isInfiniteK = app0 "isInfinite"
+  isFiniteK = app0 "isFinite"
+  isNaNK = app0 "isNaN"
+  isDenormalK = app0 "isDenormal"
+
+instance Cat.TranscendentalCat Syn a where
+  tanK = app0 "tan"
+  asinK = app0 "asin"
+  acosK = app0 "acos"
+  atanK = app0 "atan"
+  sinhK = app0 "sinh"
+  coshK = app0 "cosh"
+  tanhK = app0 "tanh"
+  asinhK = app0 "asinh"
+  acoshK = app0 "acosh"
+  atanhK = app0 "atanh"
+
+instance Cat.ArcTan2Cat Syn a where
+  arctan2K = app0 "atan2"
+
+instance Cat.FModCat Syn a where
+  fmodK = app0 "fmod"

--- a/integrations/concat-extensions/examples/categorifier-concat-extensions-examples.cabal
+++ b/integrations/concat-extensions/examples/categorifier-concat-extensions-examples.cabal
@@ -1,0 +1,55 @@
+cabal-version:  2.4
+
+name:           categorifier-concat-extensions-examples
+version:        0.1
+description:    Extends categories from `concat-examples` to support classes from
+                `categorifier-concat-extensions-category`
+homepage:       https://github.com/con-kitty/categorifier#readme
+bug-reports:    https://github.com/con-kitty/categorifier/issues
+build-type:     Simple
+tested-with:    GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2, GHC==9.2.8
+
+source-repository head
+  type: git
+  location: https://github.com/con-kitty/categorifier
+
+common defaults
+  ghc-options:
+    -Wall
+  build-depends:
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
+  default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.ConCatExtensions.Examples.Syntactic
+  other-modules:
+      Paths_categorifier_concat_extensions_examples
+  autogen-modules:
+      Paths_categorifier_concat_extensions_examples
+  build-depends:
+    , bytestring ^>=0.10.9 || ^>=0.11.0
+    , categorifier-concat-extensions-category
+    , categorifier-concat-examples
+    , categorifier-client
+    , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
+++ b/integrations/concat-extensions/integration-test/categorifier-concat-extensions-integration-test.cabal
@@ -62,11 +62,11 @@ common hierarchy-tests
     , categorifier-category
     , categorifier-client
     , categorifier-concat-integration
+    , categorifier-concat-extensions-examples
     , categorifier-concat-extensions-integration
     , categorifier-concat-extensions-integration-test
     , categorifier-hedgehog
     , categorifier-plugin
-    , concat-examples
     , either ^>=5.0.1
     , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
     , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2

--- a/integrations/concat-extensions/integration-test/test/ConCatExtensions/Main.hs
+++ b/integrations/concat-extensions/integration-test/test/ConCatExtensions/Main.hs
@@ -10,6 +10,7 @@ module Main
   )
 where
 
+import Categorifier.ConCatExtensions.Examples.Syntactic (Syn)
 import Categorifier.Hedgehog (genFloating, genIntegralBounded)
 import Categorifier.Test.ConCatExtensions.Instances (Hask (..), Term)
 import Categorifier.Test.Data (Pair (..))
@@ -42,7 +43,8 @@ mkTestTerms
   --             name   type      prefix  strategy
   [ TestCategory ''Term [t|Term|] "term" CheckCompileOnly,
     TestCategory ''(->) [t|(->)|] "plainArrow" $ ComputeFromInput [|id|],
-    TestCategory ''Hask [t|Hask|] "hask" (ComputeFromInput [|runHask|])
+    TestCategory ''Hask [t|Hask|] "hask" (ComputeFromInput [|runHask|]),
+    TestCategory ''Syn [t|Syn|] "syn" CheckCompileOnly
   ]
   -- core
   . HInsert1 (Proxy @"LamId") (TestCases (const [([t|Word8|], pure ([|genIntegralBounded|], [|show|]))]))

--- a/integrations/concat/examples/Categorifier/ConCat/Examples/Circuit.hs
+++ b/integrations/concat/examples/Categorifier/ConCat/Examples/Circuit.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | This is intended to be used /instead/ of "ConCat.Circuit" when using the "Categorifier"
+--   plugin.
+--
+--   It re-exports the original module, adding instances for classes required by "Categorifier"..
+module Categorifier.ConCat.Examples.Circuit
+  ( module ConCat.Circuit,
+  )
+where
+
+import qualified Categorifier.Category as Categorifier
+import qualified Categorifier.Client as Categorifier
+import qualified ConCat.Category as ConCat
+import ConCat.Circuit ((:>))
+import qualified ConCat.Rep as ConCat
+
+instance Categorifier.ReferenceCat (:>) a b
+
+instance
+  ( Categorifier.HasRep a,
+    r ~ Categorifier.Rep a,
+    ConCat.Ok (:>) a,
+    ConCat.Ok (:>) r,
+    -- __NB__: This constraint is only because "ConCat.Circuit" doesn't export enough for us to
+    --         define this instance directly.
+    r ~ ConCat.Rep a
+  ) =>
+  Categorifier.RepCat (:>) a r
+  where
+  reprC = ConCat.reprC
+  abstC = ConCat.abstC
+
+instance (ConCat.CoerceCat (:>) a b) => Categorifier.UnsafeCoerceCat (:>) a b where
+  unsafeCoerceK = ConCat.coerceC

--- a/integrations/concat/examples/Categorifier/ConCat/Examples/Syntactic.hs
+++ b/integrations/concat/examples/Categorifier/ConCat/Examples/Syntactic.hs
@@ -3,6 +3,8 @@
 
 -- | This is intended to be used /instead/ of "ConCat.Syntactic" when using the "Categorifier"
 --   plugin.
+--
+--   It re-exports the original module, adding instances for classes required by "Categorifier"..
 module Categorifier.ConCat.Examples.Syntactic
   ( module ConCat.Syntactic,
   )
@@ -10,14 +12,25 @@ where
 
 import qualified Categorifier.Category as Categorifier
 import qualified Categorifier.Client as Categorifier
+import qualified ConCat.Category as ConCat
 import ConCat.Syntactic
 
-instance
-  (Categorifier.HasRep a, r ~ Categorifier.Rep a, T a, T r) =>
-  Categorifier.RepCat Syn a r
-  where
+instance Categorifier.ReferenceCat Syn a b
+
+instance (Categorifier.HasRep a, r ~ Categorifier.Rep a) => Categorifier.RepCat Syn a r where
   abstC = app0' "abst"
   reprC = app0' "repr"
 
 instance Categorifier.UnsafeCoerceCat Syn a b where
   unsafeCoerceK = app0' "unsafeCoerce"
+
+-- TODO: Move these instances upstream
+
+instance (Functor f) => ConCat.Strong Syn f where
+  strength = app0 "strength"
+
+instance ConCat.TraversableCat Syn t f where
+  sequenceAC = app0 "sequenceA"
+
+instance ConCat.TracedCat Syn where
+  trace = app1 "trace"

--- a/integrations/concat/examples/categorifier-concat-examples.cabal
+++ b/integrations/concat/examples/categorifier-concat-examples.cabal
@@ -39,6 +39,7 @@ common defaults
 library
   import: defaults
   exposed-modules:
+      Categorifier.ConCat.Examples.Circuit
       Categorifier.ConCat.Examples.Syntactic
   other-modules:
       Paths_categorifier_concat_examples
@@ -48,6 +49,7 @@ library
     , bytestring ^>=0.10.9 || ^>=0.11.0
     , categorifier-category
     , categorifier-client
+    , concat-classes
     , concat-examples
     , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1
     , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0

--- a/integrations/concat/integration-test/Categorifier/Test/ConCat/Instances.hs
+++ b/integrations/concat/integration-test/Categorifier/Test/ConCat/Instances.hs
@@ -8,34 +8,11 @@ module Categorifier.Test.ConCat.Instances
   )
 where
 
-import Categorifier.Category (RepCat (..))
-import qualified Categorifier.Client as Client
 import Categorifier.Test.Hask (Hask (..))
 import Categorifier.Test.Term (Term (..), binaryZero, unaryZero)
 import qualified ConCat.Category as ConCat
-import ConCat.Circuit ((:>))
-import qualified ConCat.Rep as ConCat
-import ConCat.Syntactic (Syn, app0')
 import qualified Control.Arrow as Base
 import Data.Constraint (Dict (..), (:-) (..))
-
-instance
-  ( Client.HasRep a,
-    r ~ Client.Rep a,
-    ConCat.Ok (:>) a,
-    ConCat.Ok (:>) r,
-    -- __NB__: This constraint is only because "ConCat.Circuit" doesn't export enough for us to
-    --         define this instance directly.
-    r ~ ConCat.Rep a
-  ) =>
-  RepCat (:>) a r
-  where
-  reprC = ConCat.reprC
-  abstC = ConCat.abstC
-
-instance (Client.HasRep a, r ~ Client.Rep a) => RepCat Syn a r where
-  reprC = app0' "repr"
-  abstC = app0' "abst"
 
 -- Term
 

--- a/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
+++ b/integrations/concat/integration-test/categorifier-concat-integration-test.cabal
@@ -19,7 +19,6 @@ common defaults
     , categorifier-client
     , categorifier-plugin-test
     , concat-classes
-    , concat-examples
   ghc-options:
     -Wall
   default-language: Haskell2010
@@ -67,6 +66,7 @@ common hierarchy-tests
     , adjunctions ^>=4.4
     , categorifier-adjunctions-integration
     , categorifier-adjunctions-integration-test
+    , categorifier-concat-examples
     , categorifier-concat-integration
     , categorifier-concat-integration-test
     , categorifier-hedgehog

--- a/integrations/concat/integration-test/test/ConCat/Main.hs
+++ b/integrations/concat/integration-test/test/ConCat/Main.hs
@@ -39,6 +39,8 @@ module Main
   )
 where
 
+import Categorifier.ConCat.Examples.Circuit ((:>))
+import Categorifier.ConCat.Examples.Syntactic (Syn)
 import Categorifier.Hedgehog (genFloating, genIntegralBounded)
 import qualified Categorifier.Test.Adjunctions as Adjunctions
 import Categorifier.Test.ConCat.Instances (Hask (..), Term)
@@ -53,8 +55,6 @@ import Categorifier.Test.Tests
     mkTestTerms,
   )
 import Categorifier.Test.TotOrd (TotOrd, runTotOrd)
-import ConCat.Circuit ((:>))
-import ConCat.Syntactic (Syn)
 import Control.Arrow (Arrow (..), ArrowChoice (..))
 import Data.Bool (bool)
 import Data.Functor.Identity (Identity (..))
@@ -85,10 +85,7 @@ mkTestTerms
     (Proxy @"FmapRep")
     ( TestCases
         ( \arrow ->
-            if arrow
-              `elem` [ ''Syn, -- no Strong
-                       ''TotOrd -- #19
-                     ]
+            if arrow == ''TotOrd -- #19
               then []
               else [([t|Word8|], pure ([|genIntegralBounded|], [|show|]))]
         )
@@ -1433,10 +1430,7 @@ mkTestTerms
     (Proxy @"BareFMap")
     ( TestCases
         ( \arrow ->
-            if arrow
-              `elem` [ ''Syn, -- no Strong
-                       ''TotOrd -- no ClosedCat
-                     ]
+            if arrow == ''TotOrd -- no ClosedCat
               then []
               else
                 [ ( [t|Word8|],
@@ -1456,10 +1450,7 @@ mkTestTerms
     (Proxy @"PartialFmap")
     ( TestCases
         ( \arrow ->
-            if arrow
-              `elem` [ ''Syn, -- no Strong
-                       ''TotOrd -- #19
-                     ]
+            if arrow == ''TotOrd -- #19
               then []
               else [([t|Word8|], pure ([|Pair <$> genIntegralBounded <*> genIntegralBounded|], [|show|]))]
         )
@@ -1468,10 +1459,7 @@ mkTestTerms
     (Proxy @"Fmap")
     ( TestCases
         ( \arrow ->
-            if arrow
-              `elem` [ ''Syn, -- no Strong
-                       ''TotOrd -- #19
-                     ]
+            if arrow == ''TotOrd -- #19
               then []
               else
                 [ ( ([t|Pair|], [t|Word8|]),
@@ -1484,10 +1472,7 @@ mkTestTerms
     (Proxy @"Fmap'")
     ( TestCases
         ( \arrow ->
-            if arrow
-              `elem` [ ''Syn, -- no Strong
-                       ''TotOrd -- #19
-                     ]
+            if arrow == ''TotOrd -- #19
               then []
               else [([t|Word8|], pure ([|Pair <$> genIntegralBounded <*> genIntegralBounded|], [|show|]))]
         )
@@ -1505,10 +1490,7 @@ mkTestTerms
     (Proxy @"MapList")
     ( TestCases
         ( \arrow ->
-            if arrow
-              `elem` [ ''Syn, -- no Strong
-                       ''TotOrd -- #19
-                     ]
+            if arrow == ''TotOrd -- #19
               then []
               else
                 [ ( [t|Word8|],

--- a/integrations/unconcat/examples/Categorifier/UnconCat/Examples/Syntactic.hs
+++ b/integrations/unconcat/examples/Categorifier/UnconCat/Examples/Syntactic.hs
@@ -1,0 +1,41 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+-- | This is intended to be used /instead/ of "ConCat.Syntactic" when using the "Categorifier"
+--   plugin with `Categorifier.Hierarchy.UnconCat.hierarchy`.
+--
+--   It re-exports the original module, adding instances for classes required by `Categorifier`.
+module Categorifier.UnconCat.Examples.Syntactic
+  ( module Categorifier.ConCat.Examples.Syntactic,
+  )
+where
+
+import Categorifier.ConCat.Examples.Syntactic
+import qualified Categorifier.UnconCat as Cat
+
+instance Cat.Category Syn where
+  id = app0 "id"
+  (.) = app2 "."
+
+instance Cat.AssociativePCat Syn where
+  lassocP = app0 "lassocP"
+  rassocP = app0 "rassocP"
+
+instance Cat.ClosedCat Syn where
+  apply = app0 "apply"
+  curry = app1 "curry"
+  uncurry = app1 "uncurry"
+
+instance Cat.CoproductCat Syn where
+  inl = app0 "inl"
+  inr = app0 "inr"
+  jam = app0 "jam"
+
+instance Cat.MonoidalPCat Syn where
+  (***) = app2 "***"
+  first = app1 "first"
+  second = app1 "second"
+
+instance Cat.ProductCat Syn where
+  exl = app0 "exl"
+  exr = app0 "exr"
+  dup = app0 "dup"

--- a/integrations/unconcat/examples/categorifier-unconcat-examples.cabal
+++ b/integrations/unconcat/examples/categorifier-unconcat-examples.cabal
@@ -1,0 +1,56 @@
+cabal-version:  2.4
+
+name:           categorifier-unconcat-examples
+version:        0.1
+description:    Extends categories from `concat-examples` to support classes from
+                `categorifier-unconcat-category`
+homepage:       https://github.com/con-kitty/categorifier#readme
+bug-reports:    https://github.com/con-kitty/categorifier/issues
+build-type:     Simple
+tested-with:    GHC==8.10.1, GHC==8.10.7, GHC==9.0.1, GHC==9.2.1, GHC==9.2.2, GHC==9.2.8
+
+source-repository head
+  type: git
+  location: https://github.com/con-kitty/categorifier
+
+common defaults
+  ghc-options:
+    -Wall
+  build-depends:
+    , base ^>=4.13.0 || ^>=4.14.0 || ^>=4.15.0 || ^>=4.16.0
+  default-language: Haskell2010
+  default-extensions:
+    BangPatterns
+    DeriveDataTypeable
+    DeriveFoldable
+    DeriveFunctor
+    DeriveGeneric
+    DeriveTraversable
+    DerivingStrategies
+    FlexibleContexts
+    FlexibleInstances
+    FunctionalDependencies
+    InstanceSigs
+    LambdaCase
+    ScopedTypeVariables
+    StandaloneDeriving
+    TypeApplications
+    TypeOperators
+
+library
+  import: defaults
+  exposed-modules:
+      Categorifier.UnconCat.Examples.Syntactic
+  other-modules:
+      Paths_categorifier_unconcat_examples
+  autogen-modules:
+      Paths_categorifier_unconcat_examples
+  build-depends:
+    , bytestring ^>=0.10.9 || ^>=0.11.0
+    , categorifier-unconcat-category
+    , categorifier-concat-examples
+    , categorifier-client
+    , concat-classes
+    , ghc ^>=8.8.1 || ^>=8.10.1 || ^>=9.0.1 || ^>=9.2.1
+    , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
+    , transformers ^>=0.5.6 || ^>=0.6.0

--- a/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
+++ b/integrations/unconcat/integration-test/categorifier-unconcat-integration-test.cabal
@@ -63,9 +63,9 @@ common hierarchy-tests
     , categorifier-concat-integration
     , categorifier-hedgehog
     , categorifier-plugin
+    , categorifier-unconcat-examples
     , categorifier-unconcat-integration
     , categorifier-unconcat-integration-test
-    , concat-examples
     , either ^>=5.0.1
     , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
     , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2

--- a/integrations/unconcat/integration-test/test/UnconCat/Main.hs
+++ b/integrations/unconcat/integration-test/test/UnconCat/Main.hs
@@ -21,6 +21,7 @@ import Categorifier.Test.Tests
     mkTestTerms,
   )
 import Categorifier.Test.UnconCat.Instances (Hask (..), Term)
+import Categorifier.UnconCat.Examples.Syntactic (Syn)
 import Control.Arrow (Arrow (..), ArrowChoice (..))
 import Data.Bool (bool)
 import Data.Proxy (Proxy (..))
@@ -36,7 +37,8 @@ mkTestTerms
   --             name   type      prefix  strategy
   [ TestCategory ''Term [t|Term|] "term" CheckCompileOnly,
     TestCategory ''(->) [t|(->)|] "plainArrow" $ ComputeFromInput [|id|],
-    TestCategory ''Hask [t|Hask|] "hask" (ComputeFromInput [|runHask|])
+    TestCategory ''Hask [t|Hask|] "hask" (ComputeFromInput [|runHask|]),
+    TestCategory ''Syn [t|Syn|] "syn" CheckCompileOnly
   ]
   -- core
   . HInsert1 (Proxy @"LamId") (TestCases (const [([t|Word8|], pure ([|genIntegralBounded|], [|show|]))]))

--- a/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
+++ b/integrations/vec/integration-test/categorifier-vec-integration-test.cabal
@@ -66,6 +66,7 @@ common hierarchy-tests
   build-depends:
     , categorifier-concat-integration
     , categorifier-concat-extensions-category
+    , categorifier-concat-extensions-examples
     , categorifier-concat-extensions-integration
     , categorifier-concat-extensions-integration-test
     , categorifier-category
@@ -75,7 +76,6 @@ common hierarchy-tests
     , categorifier-plugin-test
     , categorifier-vec-integration
     , categorifier-vec-integration-test
-    , concat-classes
     , ghc-prim ^>=0.5.3 || ^>=0.6.0 || ^>=0.7.0 || ^>=0.8.0
     , hedgehog ^>=1.0.3 || ^>=1.1 || ^>=1.2
     , template-haskell ^>=2.15.0 || ^>=2.16.0 || ^>=2.17.0 || ^>=2.18.0

--- a/integrations/vec/integration-test/test/Vec/Main.hs
+++ b/integrations/vec/integration-test/test/Vec/Main.hs
@@ -13,6 +13,7 @@ module Main
   )
 where
 
+import Categorifier.ConCatExtensions.Examples.Syntactic (Syn)
 import Categorifier.Hedgehog (genFloating, genIntegralBounded)
 import Categorifier.Test.ConCatExtensions.Instances (Hask (..), Term)
 import Categorifier.Test.HList (HMap1 (..))
@@ -41,7 +42,8 @@ mkTestTerms
   --             name   type      prefix  strategy
   [ TestCategory ''Term [t|Term|] "term" CheckCompileOnly,
     TestCategory ''(->) [t|(->)|] "plainArrow" $ ComputeFromInput [|id|],
-    TestCategory ''Hask [t|Hask|] "hask" (ComputeFromInput [|runHask|])
+    TestCategory ''Hask [t|Hask|] "hask" (ComputeFromInput [|runHask|]),
+    TestCategory ''Syn [t|Syn|] "syn" CheckCompileOnly
   ]
   . HInsert1
     (Proxy @"BindVec")


### PR DESCRIPTION
`concat-examples` contains a number of useful categories, but they’re not _quite_ usable by Categorifier in general.

This sets up a pattern for supporting them and implements it for the `ConCat.Syntactic` category. It defines the plugin-specific instances for them (and moves existing ones out of test-specific code) and also defines `concat-extensions` and `unconcat` instances.

`Syntactic` is a trivial category, but the pattern should work across others, which can be integrated over time.